### PR TITLE
Added D2RQ scripts, updated ontology (DocumentContent, Container)

### DIFF
--- a/DB/Virtuoso/ATLAS.owl
+++ b/DB/Virtuoso/ATLAS.owl
@@ -44,6 +44,36 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute">
+        <rdfs:label>ContainerObjectAttribute</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#bunchspacingINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#bunchspacingINcontainer">
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#hasContainerBunchspacing"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#BunchSpacing"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>bunchspacingINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#campaignINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#campaignINcontainer">
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#hasContainerCampaign"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Campaign"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>campaignINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#containsPublication -->
 
     <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#containsPublication">
@@ -52,6 +82,39 @@
         <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Paper"/>
         <rdfs:comment>Journal issue contains the following publication</rdfs:comment>
         <rdfs:label>containsPublication</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#energyINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#energyINcontainer">
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#hasContainerECMEnergy"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Energy"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>energyINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#generatorINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#generatorINcontainer">
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#hasContainerGeneratorName"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#GeneratorName"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>generatorINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#geometryINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#geometryINcontainer">
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#hasContainerGeometryVersion"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#GeometryVersion"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>geometryINcontainer</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -88,6 +151,192 @@
         <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Campaign"/>
         <rdfs:comment>Campaign</rdfs:comment>
         <rdfs:label>hasCampaign</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerAtlasRelease -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerAtlasRelease">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#releaseINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#AtlasRelease"/>
+        <rdfs:label>hasContainerAtlasRelease</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerBunchspacing -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerBunchspacing">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#BunchSpacing"/>
+        <rdfs:label>hasContainerBunchspacing</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerCampaign -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerCampaign">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Campaign"/>
+        <rdfs:label>hasContainerCampaign</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerDataTakingPeriod -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerDataTakingPeriod">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#periodINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DataTakingPeriod"/>
+        <rdfs:label>hasContainerDataTakingPeriod</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerECMEnergy -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerECMEnergy">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Energy"/>
+        <rdfs:label>hasContainerECMEnergy</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerGeneratorName -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerGeneratorName">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Generator"/>
+        <rdfs:label>hasContainerGeneratorName</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerGeometryVersion -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerGeometryVersion">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#GeometryVersion"/>
+        <rdfs:label>hasContainerGeometryVersion</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerKeyword -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerKeyword">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#keywordINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Keyword"/>
+        <rdfs:label>hasContainerKeyword</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerPhysicsGroup -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerPhysicsGroup">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#physicsGroupINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#PhysGroup"/>
+        <rdfs:label>hasContainerPhysicsGroup</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerPileup -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerPileup">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#pileupINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Pileup"/>
+        <rdfs:label>hasContainerPileup</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionStep -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionStep">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#prodStepINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionStep"/>
+        <rdfs:label>hasContainerProductionStep</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionTag -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionTag">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#prodTagINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionTag"/>
+        <rdfs:label>hasContainerProductionTag</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerProject -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerProject">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#projectINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Project"/>
+        <rdfs:label>hasContainerProject</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerTransformationPackage -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerTransformationPackage">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#transformationINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#TransformationPackage"/>
+        <rdfs:label>hasContainerTransformationPackage</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerTriggerConfig -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerTriggerConfig">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <owl:inverseOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#triggerINcontainer"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#TriggerConfig"/>
+        <rdfs:label>hasContainerTriggerConfig</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerVirtualOrganization -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerVirtualOrganization">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#VirtualOrganization"/>
+        <rdfs:label>hasContainerVirtualOrganization</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -131,6 +380,27 @@
         <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Project"/>
         <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DataTakingPeriod"/>
         <rdfs:label>hasDataTakingPeriod</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDataset -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDataset">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerObjectAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Dataset"/>
+        <rdfs:label>hasDataset</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDocument -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDocument">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DocumentContent"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+        <rdfs:label>hasDocument</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -279,6 +549,16 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#keywordINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#keywordINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Keyword"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>keywordINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#mentionsDataSample -->
 
     <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#mentionsDataSample">
@@ -350,6 +630,76 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#mentionsYear -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#mentionsYear">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DocumentContent"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Year"/>
+        <rdfs:label>mentionsYear</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#periodINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#periodINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DataTakingPeriod"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>periodINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#physicsGroupINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#physicsGroupINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#PhysGroup"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>physicsGroupINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#pileupINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#pileupINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Pileup"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>pileupINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#prodStepINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#prodStepINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionStep"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>prodStepINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#prodTagINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#prodTagINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionTag"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>prodTagINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#projectINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#projectINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Project"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>projectINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#publishedIn -->
 
     <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#publishedIn">
@@ -368,6 +718,36 @@
         <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DataSample"/>
         <rdfs:comment>Link between document and DataSample</rdfs:comment>
         <rdfs:label>referTo</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#releaseINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#releaseINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#AtlasRelease"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>releaseINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#transformationINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#transformationINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#TransformationPackage"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>transformationINcontainer</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#triggerINcontainer -->
+
+    <owl:ObjectProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#triggerINcontainer">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#TriggerConfig"/>
+        <rdfs:range rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>triggerINcontainer</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -420,6 +800,23 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute">
+        <rdfs:comment>ContainerAttribute</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#DatasetAttribute -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#DatasetAttribute">
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Dataset"/>
+        <rdfs:label>DatasetAttribute</rdfs:label>
+    </owl:DatatypeProperty>
     
 
 
@@ -535,6 +932,115 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerDataType -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerDataType">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasContainerDataType</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerID -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerID">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label>hasContainerID</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerName -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerName">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasContainerName</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionStatus -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionStatus">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasContainerProductionStatus</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionTimestamp -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerProductionTimestamp">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
+        <rdfs:label>hasContainerProductionTimestamp</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerRequestID -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerRequestID">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label>hasContainerRequestID</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerRunNumber -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerRunNumber">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
+        <rdfs:label>hasContainerRunNumber</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerSizeBytes -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerSizeBytes">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
+        <rdfs:label>hasContainerSizeBytes</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerTotalEvents -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerTotalEvents">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label>hasContainerTotalEvents</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasContainerTotalFiles -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasContainerTotalFiles">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label>hasContainerTotalFiles</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#hasControlNumber -->
 
     <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasControlNumber">
@@ -581,6 +1087,39 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDataSampleDatasetName -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDataSampleDatasetName">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DatasetAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Dataset"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasDataSampleDatasetName</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDatasetEvents -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDatasetEvents">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DatasetAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Dataset"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label>hasDatasetEvents</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDatasetFiles -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDatasetFiles">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DatasetAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Dataset"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label>hasDatasetFiles</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDatasetID -->
 
     <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDatasetID">
@@ -603,12 +1142,33 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDatasetNumber -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDatasetNumber">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DatasetAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Dataset"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDatasetSize -->
 
     <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDatasetSize">
         <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DataSample"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <rdfs:label>hasDatasetSize</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasDatasetSizeBytes -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDatasetSizeBytes">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DatasetAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Dataset"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
+        <rdfs:label>hasDatasetSizeBytes</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -626,6 +1186,7 @@
     <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasDocumentContentDescription">
         <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DocumentContent"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasDocumentContentDescription</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -898,6 +1459,94 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskComment -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskComment">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasTaskComment</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskID -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskID">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label>hasTaskID</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskName -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskName">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasTaskName</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskProvenance -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskProvenance">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasTaskProvenance</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskStartTime -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskStartTime">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
+        <rdfs:label>hasTaskStartTime</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskStatus -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskStatus">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasTaskStatus</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskSubmitTime -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskSubmitTime">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
+        <rdfs:label>hasTaskSubmitTime</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTaskUsername -->
+
+    <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTaskUsername">
+        <rdfs:subPropertyOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ContainerAttribute"/>
+        <rdfs:domain rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>hasTaskUsername</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#hasTimestamp -->
 
     <owl:DatatypeProperty rdf:about="http://nosql.tpu.ru/ontology/ATLAS#hasTimestamp">
@@ -994,6 +1643,24 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#AtlasRelease -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#AtlasRelease">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>AtlasRelease</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#BunchSpacing -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#BunchSpacing">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>BunchSpacing</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#Campaign -->
 
     <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#Campaign">
@@ -1008,6 +1675,14 @@
     <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#ConfNote">
         <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <rdfs:label>ConfNote</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#Container -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#Container">
+        <rdfs:label>Container</rdfs:label>
     </owl:Class>
     
 
@@ -1052,6 +1727,15 @@
     <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#DataTakingPeriod">
         <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ExperimentAttribute"/>
         <rdfs:label>DataTakingPeriod</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#Dataset -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#Dataset">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Container"/>
+        <rdfs:label>Dataset</rdfs:label>
     </owl:Class>
     
 
@@ -1109,11 +1793,37 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#GeneratorName -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#GeneratorName">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>GeneratorName</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#GeometryVersion -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#GeometryVersion">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>GeometryVersion</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#JournalIssue -->
 
     <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#JournalIssue">
         <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <rdfs:label>JournalIssue</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#Keyword -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#Keyword">
+        <rdfs:label>Keyword</rdfs:label>
     </owl:Class>
     
 
@@ -1171,11 +1881,37 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#Pileup -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#Pileup">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>Pileup</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration">
+        <rdfs:label>ProductionConfiguration</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#ProductionStep -->
 
     <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#ProductionStep">
         <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#DataSampleAttribute"/>
         <rdfs:label>ProductionStep</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#ProductionTag -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#ProductionTag">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>ProductionTag</rdfs:label>
     </owl:Class>
     
 
@@ -1207,11 +1943,47 @@
     
 
 
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#Subcampaign -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#Subcampaign">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#Campaign"/>
+        <rdfs:label>Subcampaign</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://nosql.tpu.ru/ontology/ATLAS#SupportingDocument -->
 
     <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#SupportingDocument">
         <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <rdfs:label>SupportingDocument</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#TransformationPackage -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#TransformationPackage">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>TransformationPackage</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#TriggerConfig -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#TriggerConfig">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>TriggerConfig</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://nosql.tpu.ru/ontology/ATLAS#VirtualOrganization -->
+
+    <owl:Class rdf:about="http://nosql.tpu.ru/ontology/ATLAS#VirtualOrganization">
+        <rdfs:subClassOf rdf:resource="http://nosql.tpu.ru/ontology/ATLAS#ProductionConfiguration"/>
+        <rdfs:label>VirtualOrganization</rdfs:label>
     </owl:Class>
     
 

--- a/DB/Virtuoso/catalog-v001.xml
+++ b/DB/Virtuoso/catalog-v001.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1490261657580" name="http://nosql.tpu.ru/ontology/ATLAS" uri="ATLAS.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1495744420486" name="http://nosql.tpu.ru/ontology/ATLAS" uri="ATLAS.owl"/>
     </group>
 </catalog>

--- a/Utils/D2RQ/generate_mapping/map_everything.sh
+++ b/Utils/D2RQ/generate_mapping/map_everything.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./generate-mapping -o mapping.ttl -d oracle.jdbc.OracleDriver -u [USER] -p [PASSWORD] jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch

--- a/Utils/D2RQ/generate_mapping/map_important_tables.sh
+++ b/Utils/D2RQ/generate_mapping/map_important_tables.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./generate-mapping -o mapping.ttl -d oracle.jdbc.OracleDriver -u [USER] -p [PASSWORD] --tables T_INPUT_DATASET,T_PRODUCTION_DATASET,T_PRODUCTION_CONTAINER,T_PRODMANAGER_REQUEST,T_PRODUCTION_TASK,ATLAS_DEFT.T_HASHTAG,ALTAS_DEFT.T_T_HT_TO_TASK jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch

--- a/Utils/D2RQ/generate_mapping/map_one_table.sh
+++ b/Utils/D2RQ/generate_mapping/map_one_table.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./generate-mapping -o $2.ttl -d oracle.jdbc.OracleDriver -u [USER] -p [PASSWORD] --tables $1 jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch

--- a/Utils/D2RQ/generate_mapping/readme.txt
+++ b/Utils/D2RQ/generate_mapping/readme.txt
@@ -1,0 +1,11 @@
+map_one_table.sh table filename
+Generates mapping of one table and stores into filename
+
+map_important_tables.sh
+Creates mapping named mapping.ttl for the following tables: T_INPUT_DATASET,T_PRODUCTION_DATASET,T_PRODUCTION_CONTAINER,T_PRODMANAGER_REQUEST,T_PRODUCTION_TASK,ATLAS_DEFT.T_HASHTAG,ALTAS_DEFT.T_T_HT_TO_TASK
+
+map_everything.sh
+Attemppts to build a full DB map. Failed due to timeout in 100% cases so far.
+
+
+!!WARNING!! Before use, replace [USER] and [PASSWORD] with real username and password for the DB.

--- a/Utils/D2RQ/instructions/d2rq_setup.txt
+++ b/Utils/D2RQ/instructions/d2rq_setup.txt
@@ -1,0 +1,16 @@
+1) Requirements:
+D2RQ needs Java 1.5 or later to run;
+
+2) Installing D2RQ:
+1. Download and extract the archive into a suitable location.
+2. Download the Oracle JDBC driver. The correct driver is ojdbc7.jar, it can be obtained from Oracle website after accepting licence agreement. Place the driver to /lib/db-drivers.
+
+3) Configuring the server:
+1. Generate a mapping file for your database schema using the generate-mapping tool. (Does not work for majority of CERN databases, generated mappinga are lacking about 90% tables)
+2. Edit mapping to reflect DB structure and desired ontology. This is extremely time consuming, 90% setup time is spent on the mapping editing. The syntax is described here: http://d2rq.org/d2rq-language
+
+4) Running the server:
+Start the server: d2r-server mapping.ttl
+The server is now ready to accept queries.
+
+

--- a/Utils/D2RQ/readme.txt
+++ b/Utils/D2RQ/readme.txt
@@ -1,0 +1,5 @@
+generate_mapping contains scripts for automatically creating DB mappings.
+server contains various server startup scripts.
+ttls contains endpoint configurations.
+
+Scripts must be in the same directory as D2RQ server to work properly.

--- a/Utils/D2RQ/server/readme.txt
+++ b/Utils/D2RQ/server/readme.txt
@@ -1,0 +1,4 @@
+server-start.sh starts D2RQ server.
+server-watchdog.sh starts D2RQ server and restarts it after waiting 30 seconds in case of crash.
+sparql_query.sh runs a SPARQL query it accepts as a first parameter (standalone script, high startup cost, does not require server running)
+sparql_query_file.sh runs a SPARQL query from a file it accepts as a first parameter (standalone script, high startup cost, does not require server running)

--- a/Utils/D2RQ/server/server-start.sh
+++ b/Utils/D2RQ/server/server-start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./d2r-server mapping.ttl

--- a/Utils/D2RQ/server/server-watchdog.sh
+++ b/Utils/D2RQ/server/server-watchdog.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+until ./d2r-server mapping.ttl; do
+    echo "Server 'myserver' crashed with exit code $?.  Respawning.." >&2
+    sleep 30
+done

--- a/Utils/D2RQ/server/sparql_query.sh
+++ b/Utils/D2RQ/server/sparql_query.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+d2r-query mapping.ttl $1

--- a/Utils/D2RQ/server/sparql_query_file.sh
+++ b/Utils/D2RQ/server/sparql_query_file.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+d2r-query mapping.ttl @$1

--- a/Utils/D2RQ/ttls/ATLAS_DEFT.T_HASHTAG.ttl
+++ b/Utils/D2RQ/ttls/ATLAS_DEFT.T_HASHTAG.ttl
@@ -1,0 +1,48 @@
+@prefix map: <#> .
+@prefix db: <> .
+@prefix vocab: <vocab/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix jdbc: <http://d2rq.org/terms/jdbc/> .
+
+map:database a d2rq:Database;
+	d2rq:jdbcDriver "oracle.jdbc.OracleDriver";
+	d2rq:jdbcDSN "jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch";
+	d2rq:username "[USER]";
+	d2rq:password "[PASSWORD]";
+	.
+
+# Table ATLAS_DEFT.T_HASHTAG
+map:ATLAS_DEFT_T_HASHTAG a d2rq:ClassMap;
+	d2rq:dataStorage map:database;
+	d2rq:uriPattern "ATLAS_DEFT/T_HASHTAG/@@ATLAS_DEFT.T_HASHTAG.HT_ID@@";
+	d2rq:class vocab:ATLAS_DEFT_T_HASHTAG;
+	d2rq:classDefinitionLabel "ATLAS_DEFT.T_HASHTAG";
+	.
+map:ATLAS_DEFT_T_HASHTAG__label a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property rdfs:label;
+	d2rq:pattern "T_HASHTAG #@@ATLAS_DEFT.T_HASHTAG.HT_ID@@";
+	.
+map:ATLAS_DEFT_T_HASHTAG_HT_ID a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property vocab:ATLAS_DEFT_T_HASHTAG_HT_ID;
+	d2rq:propertyDefinitionLabel "T_HASHTAG HT_ID";
+	d2rq:column "ATLAS_DEFT.T_HASHTAG.HT_ID";
+	d2rq:datatype xsd:decimal;
+	.
+map:ATLAS_DEFT_T_HASHTAG_HASHTAG a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property vocab:ATLAS_DEFT_T_HASHTAG_HASHTAG;
+	d2rq:propertyDefinitionLabel "T_HASHTAG HASHTAG";
+	d2rq:column "ATLAS_DEFT.T_HASHTAG.HASHTAG";
+	.
+map:ATLAS_DEFT_T_HASHTAG_TYPE a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property vocab:ATLAS_DEFT_T_HASHTAG_TYPE;
+	d2rq:propertyDefinitionLabel "T_HASHTAG TYPE";
+	d2rq:column "ATLAS_DEFT.T_HASHTAG.TYPE";
+	.
+

--- a/Utils/D2RQ/ttls/failed_mappings/T_INPUT_DATASET.ttl
+++ b/Utils/D2RQ/ttls/failed_mappings/T_INPUT_DATASET.ttl
@@ -1,0 +1,16 @@
+@prefix map: <#> .
+@prefix db: <> .
+@prefix vocab: <vocab/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix jdbc: <http://d2rq.org/terms/jdbc/> .
+
+map:database a d2rq:Database;
+	d2rq:jdbcDriver "oracle.jdbc.OracleDriver";
+	d2rq:jdbcDSN "jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch";
+	d2rq:username "[USER]";
+	d2rq:password "[PASSWORD]";
+	.
+

--- a/Utils/D2RQ/ttls/failed_mappings/T_PRODMANAGER_REQUEST.ttl
+++ b/Utils/D2RQ/ttls/failed_mappings/T_PRODMANAGER_REQUEST.ttl
@@ -1,0 +1,16 @@
+@prefix map: <#> .
+@prefix db: <> .
+@prefix vocab: <vocab/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix jdbc: <http://d2rq.org/terms/jdbc/> .
+
+map:database a d2rq:Database;
+	d2rq:jdbcDriver "oracle.jdbc.OracleDriver";
+	d2rq:jdbcDSN "jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch";
+	d2rq:username "[USER]";
+	d2rq:password "[PASSWORD]";
+	.
+	

--- a/Utils/D2RQ/ttls/failed_mappings/T_PRODUCTION_CONTAINER.ttl
+++ b/Utils/D2RQ/ttls/failed_mappings/T_PRODUCTION_CONTAINER.ttl
@@ -1,0 +1,17 @@
+@prefix map: <#> .
+@prefix db: <> .
+@prefix vocab: <vocab/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix jdbc: <http://d2rq.org/terms/jdbc/> .
+
+map:database a d2rq:Database;
+	d2rq:jdbcDriver "oracle.jdbc.OracleDriver";
+	d2rq:jdbcDSN "jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch";
+	d2rq:username "[USER]";
+	d2rq:password "[PASSWORD]";
+	.
+	
+	

--- a/Utils/D2RQ/ttls/failed_mappings/T_PRODUCTION_DATASET.ttl
+++ b/Utils/D2RQ/ttls/failed_mappings/T_PRODUCTION_DATASET.ttl
@@ -1,0 +1,17 @@
+@prefix map: <#> .
+@prefix db: <> .
+@prefix vocab: <vocab/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix jdbc: <http://d2rq.org/terms/jdbc/> .
+
+map:database a d2rq:Database;
+	d2rq:jdbcDriver "oracle.jdbc.OracleDriver";
+	d2rq:jdbcDSN "jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch";
+	d2rq:username "[USER]";
+	d2rq:password "[PASSWORD]";
+	.
+	
+	

--- a/Utils/D2RQ/ttls/mapping.ttl
+++ b/Utils/D2RQ/ttls/mapping.ttl
@@ -1,0 +1,79 @@
+@prefix map: <#> .
+@prefix db: <> .
+@prefix vocab: <vocab/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix jdbc: <http://d2rq.org/terms/jdbc/> .
+
+map:database a d2rq:Database;
+	d2rq:jdbcDriver "oracle.jdbc.OracleDriver";
+	d2rq:jdbcDSN "jdbc:oracle:thin:@//ADCR2-ADG-S.cern.ch:10121/ADCR.cern.ch";
+	d2rq:username "[USER]";
+	d2rq:password "[PASSWORD]";
+	.
+
+# Table T_PRODUCTION_DATASET
+map:T_PRODUCTION_DATASET a d2rq:ClassMap;
+	d2rq:dataStorage map:database;
+	d2rq:uriPattern "T_PRODUCTION_DATASET/@@T_PRODUCTION_DATASET.NAME@@";
+	d2rq:class vocab:T_PRODUCTION_DATASET;
+	d2rq:classDefinitionLabel "T_PRODUCTION_DATASET";	
+	
+map:T_PRODUCTION_DATASET__label a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:T_PRODUCTION_DATASET;
+	d2rq:property rdfs:label;
+	d2rq:pattern "DS_NAME #@@T_PRODUCTION_DATASET.NAME@@";
+	
+map:T_PRODUCTION_DATASET_LABEL a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:T_PRODUCTION_DATASET;
+	d2rq:property vocab:T_PRODUCTION_DATASET_NAME;
+	d2rq:propertyDefinitionLabel "T_PRODUCTION_DATASET_NAME";
+	d2rq:column "T_PRODUCTION_DATASET.NAME";
+	d2rq:datatype xsd:string;
+	.
+map:T_PRODUCTION_DATASET_PHYS_GROUP a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:T_PRODUCTION_DATASET;
+	d2rq:property vocab:T_PRODUCTION_DATASET_PHYS_GROUP;
+	d2rq:propertyDefinitionLabel "T_PRODUCTION_DATASET_PHYS_GROUP";
+	d2rq:column "T_PRODUCTION_DATASET.PHYS_GROUP";
+	.
+map:T_PRODUCTION_DATASET_TASKID a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:T_PRODUCTION_DATASET;
+	d2rq:property vocab:T_PRODUCTION_DATASET_TASKID;
+	d2rq:propertyDefinitionLabel "DATASET_TASKID";
+	d2rq:column "T_PRODUCTION_DATASET.TASKID";
+
+# Table ATLAS_DEFT.T_HASHTAG
+map:ATLAS_DEFT_T_HASHTAG a d2rq:ClassMap;
+	d2rq:dataStorage map:database;
+	d2rq:uriPattern "ATLAS_DEFT/T_HASHTAG/@@ATLAS_DEFT.T_HASHTAG.HT_ID@@";
+	d2rq:class vocab:ATLAS_DEFT_T_HASHTAG;
+	d2rq:classDefinitionLabel "ATLAS_DEFT.T_HASHTAG";
+	.
+map:ATLAS_DEFT_T_HASHTAG__label a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property rdfs:label;
+	d2rq:pattern "T_HASHTAG #@@ATLAS_DEFT.T_HASHTAG.HT_ID@@";
+	.
+map:ATLAS_DEFT_T_HASHTAG_HT_ID a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property vocab:ATLAS_DEFT_T_HASHTAG_HT_ID;
+	d2rq:propertyDefinitionLabel "T_HASHTAG HT_ID";
+	d2rq:column "ATLAS_DEFT.T_HASHTAG.HT_ID";
+	d2rq:datatype xsd:decimal;
+	.
+map:ATLAS_DEFT_T_HASHTAG_HASHTAG a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property vocab:ATLAS_DEFT_T_HASHTAG_HASHTAG;
+	d2rq:propertyDefinitionLabel "T_HASHTAG HASHTAG";
+	d2rq:column "ATLAS_DEFT.T_HASHTAG.HASHTAG";
+	.
+map:ATLAS_DEFT_T_HASHTAG_TYPE a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:ATLAS_DEFT_T_HASHTAG;
+	d2rq:property vocab:ATLAS_DEFT_T_HASHTAG_TYPE;
+	d2rq:propertyDefinitionLabel "T_HASHTAG TYPE";
+	d2rq:column "ATLAS_DEFT.T_HASHTAG.TYPE";
+	.
+

--- a/Utils/D2RQ/ttls/readme.txt
+++ b/Utils/D2RQ/ttls/readme.txt
@@ -1,0 +1,7 @@
+failed_mappings contains examples of mappings returned by generate_mapping that differ from expected result (empty mappings)
+
+ATLAS_DEFT.T_HASHTAG.ttl is an example of successfully auto-generated mapping.
+
+mapping.ttl is an unfinished prototype mapping for the ProdSys2 endpoint.
+
+!!WARNING!! Replace [USER] and [PASSWORD] with real DB credentials before using any mappings.


### PR DESCRIPTION
D2RQ scripts for server startup, generating mappings, sample mappings, setup instructions.

Ontology:
DocumentContent updated according to latest requirements.
Container ontology fully merged, with some changes:

Campaign: merged
Subcampaign: added

DataTakingPeriod: merged
Level, Period, Year merged
Energy: merged
Generator: merged
PhysicsGroup: merged
ProductionStep: merged
ProductionTags: renamed to ProductionTag
Project: merged

hasRunNumber => hasContainerRunNumber

All properties with domain Dataset+Container have their domain changed to Dataset.

hasDatasetFiles type was set to integer (had no type initially)

hasDAtasetName => hasDataSampleDAtasetName

hasDatasetSizeBytes - type changed from integer to long.