### PR TITLE
pyDKB configuration

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/dkbID.conf
+++ b/Utils/Dataflow/pyDKB/dataflow/dkbID.conf
@@ -3,12 +3,12 @@
     "priority": ["CDS", "GLANCE"],
 
     "CDS": {
-      "keywords": ["cdsID.internal", "cdsID.report_number", "cdsID"],
+      "keywords": ["CDS.report_number.internal", "CDS.report_number.report_number", "CDS.report_number"],
       "prefix": "CDS"
     },
 
     "GLANCE": {
-      "keywords": [ "glanceID" ]
+      "keywords": [ "GLANCE.ref_code", "GLANCE.id" ]
     }
   }
 }


### PR DESCRIPTION
Configured pyDKB to use following values for Document dkbID generation (listed in order of priority):
* CDS:
    * report_number['internal']
    * report_number['report_number']
    * report_number
* GLANCE:
    * ref_code
    * id