### PR TITLE
pyDKB: Processor Stage output full implementation

### DIFF
--- a/Utils/Dataflow/pyDKB/common/hdfs.py
+++ b/Utils/Dataflow/pyDKB/common/hdfs.py
@@ -28,6 +28,20 @@ def check_stderr(proc, timeout=None):
             proc.wait()
     return proc.poll()
 
+def putfile(fname, dest):
+    """ Upload file to HDFS. """
+    cmd = ["hadoop", "fs", "-put", fname, dest]
+    try:
+        proc = subprocess.Popen(cmd,
+                                stdin =subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                stdout=DEVNULL)
+        if check_stderr(proc):
+            raise(subprocess.CalledProcessError(proc.returncode, cmd))
+    except (subprocess.CalledProcessError, OSError, HDFSException), err:
+        raise RuntimeError("(ERROR) Failed to put file to HDFS: %s\n"
+                           "Error message: %s\n" % (fname, err))
+
 def getfile(fname):
     """ Download file from HDFS.
 

--- a/Utils/Dataflow/pyDKB/dataflow/messages.py
+++ b/Utils/Dataflow/pyDKB/dataflow/messages.py
@@ -29,6 +29,8 @@ class AbstractMessage(object):
     msg_type = None
     native_types = []
 
+    _ext = ".out"
+
     decoded = None
     encoded = None
 
@@ -66,11 +68,18 @@ class AbstractMessage(object):
         """ Return message content. """
         return self.decode()
 
+    @classmethod
+    def extension(cls):
+        """ Return file extension corresponding this message type. """
+        return cls._ext
+
 
 class JSONMessage(AbstractMessage):
     """ Message in JSON format. """
     msg_type = messageType.JSON
     native_types = [dict]
+
+    _ext = ".json"
 
     def decode(self, code=codeType.STRING):
         """ Decode original data as JSON. """
@@ -105,10 +114,13 @@ class TTLMessage(AbstractMessage):
     Single message = single TTL statement
     """
     msg_type = messageType.TTL
+
     try:
         native_types = [str, unicode]
     except NameError:
         native_types = [str]
+
+    _ext = ".ttl"
 
     def decode(self, code=codeType.STRING):
         """ Decode original data as TTL.

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
@@ -177,14 +177,14 @@ class AbstractProcessorStage(AbstractStage):
         if   self.ARGS.source == 'h':
             if self.ARGS.input_files or self.ARGS.mode == 'm':
             # In MapReduce mode we`re going to get the list of files from STDIN
-                self.__input = self.__hdfsFiles()
+                self.__input = self.__hdfs_in_files()
             else:
-                self.__input = self.__hdfsDir()
+                self.__input = self.__hdfs_in_dir()
         elif self.ARGS.source == 'f':
             if self.ARGS.input_files:
-                self.__input = self.__localFiles()
+                self.__input = self.__local_in_files()
             else:
-                self.__input = self.__localDir()
+                self.__input = self.__local_in_dir()
         elif self.ARGS.source == 's':
             self.__input = [sys.stdin]
         else:
@@ -268,7 +268,7 @@ class AbstractProcessorStage(AbstractStage):
         print message.content()
 
 
-    def __localDir(self):
+    def __local_in_dir(self):
         """ Call file descriptors generator for files in local dir. """
         dirname = self.ARGS.input_dir
         if not dirname:
@@ -284,9 +284,9 @@ class AbstractProcessorStage(AbstractStage):
         if not files:
             return []
         self.ARGS.input_files = files
-        return self.__localFiles()
+        return self.__local_in_files()
 
-    def __localFiles(self):
+    def __local_in_files(self):
         """ Generator for file descriptors to read data from (local files). """
         filenames = self.ARGS.input_files
         for f in filenames:
@@ -299,16 +299,16 @@ class AbstractProcessorStage(AbstractStage):
                 yield infile
 
 
-    def __hdfsDir(self):
+    def __hdfs_in_dir(self):
         """ Call file descriptors generator for files in HDFS dir. """
         dirname = self.ARGS.input_dir
         files = hdfs.listdir(dirname, "f")
         self.ARGS.input_files = files
         if not files:
             return []
-        return self.__hdfsFiles()
+        return self.__hdfs_in_files()
 
-    def __hdfsFiles(self):
+    def __hdfs_in_files(self):
         """ Generator for file descriptors to read data from (HDFS files). """
         filenames = self.ARGS.input_files
         if not filenames:

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
@@ -199,6 +199,8 @@ class AbstractProcessorStage(AbstractStage):
     def run(self):
         """ Run process() for every input() message. """
         for msg in self.input():
+            if not msg:
+                continue
             out = self.process(msg)
             self.output(out)
 
@@ -213,12 +215,13 @@ class AbstractProcessorStage(AbstractStage):
         """ Verify and parse input message.
 
         Is called from input() method.
-        Throws ValueError.
         """
         messageClass = self.__input_message_class
         try:
-            return messageClass(input_message)
-        except ValueError, err:
+            msg = messageClass(input_message)
+            msg.decode()
+            return msg
+        except (ValueError, TypeError), err:
             sys.stderr.write("(WARN) Failed to read input message as %s.\n"
                              "Cause: %s\n" % (messageClass.typeName(), err))
             return None

--- a/Utils/Dataflow/pyDKB/dataflow/stage/processors.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/processors.py
@@ -33,6 +33,7 @@ class JSONProcessorStage(AbstractProcessorStage):
         except ValueError, err:
             sys.stderr.write("(WARN) failed to read input file %s as %s: %s.\n"
                        % (fd.name, self.input_message_class().typeName(), err))
+            yield None
 
 class TTLProcessorStage(AbstractProcessorStage):
     """ TTL2TTL Processor Stage

--- a/Utils/Dataflow/pyDKB/dataflow/types.py
+++ b/Utils/Dataflow/pyDKB/dataflow/types.py
@@ -2,9 +2,10 @@
 Type definitions for library objects.
 """
 
-__all__ = ["dataType", "messageType"]
+__all__ = ["dataType", "messageType", "codeType"]
 
 from ..common import Type
 
 dataType = Type("DOCUMENT", "AUTHOR", "DATASET")
 messageType = Type("STRING", "JSON", "TTL")
+codeType = Type("STRING")

--- a/Utils/Dataflow/test/pyDKB/README
+++ b/Utils/Dataflow/test/pyDKB/README
@@ -8,11 +8,12 @@ pyDKB testing stage.
 
 Run as:
 
-  ./json2TTL.py -i input 2>&1 | less
-  ./json2TTL.py input/196.json 2>&1 | less
+  ./json2TTL.py -i input
+  ./json2TTL.py input/196.json
   cat << EOF | ./json2TTL.py -m s | less
   {"a": 1}
   {"b": 2}
   EOF
+  ./json2TTL.py --hdfs -i /my/test/input
 
 etc

--- a/Utils/Dataflow/test/pyDKB/README
+++ b/Utils/Dataflow/test/pyDKB/README
@@ -1,0 +1,18 @@
+=============
+* Stage XX  *
+=============
+
+1. Description
+--------------
+pyDKB testing stage.
+
+Run as:
+
+  ./json2TTL.py -i input 2>&1 | less
+  ./json2TTL.py input/196.json 2>&1 | less
+  cat << EOF | ./json2TTL.py -m s | less
+  {"a": 1}
+  {"b": 2}
+  EOF
+
+etc

--- a/Utils/Dataflow/test/pyDKB/input
+++ b/Utils/Dataflow/test/pyDKB/input
@@ -1,0 +1,1 @@
+../../030_PDFAnalyzer/export/

--- a/Utils/Dataflow/test/pyDKB/json2TTL.py
+++ b/Utils/Dataflow/test/pyDKB/json2TTL.py
@@ -24,6 +24,7 @@ def main(args):
 
   stage.parse_args(args)
   stage.run()
+  stage.stop()
 
 if __name__ == '__main__':
   main(sys.argv[1:])

--- a/Utils/Dataflow/test/pyDKB/json2TTL.py
+++ b/Utils/Dataflow/test/pyDKB/json2TTL.py
@@ -9,13 +9,14 @@ sys.path.append("../../")
 
 import pyDKB
 
-def process(msg):
+def process(stage, msg):
   """
   Input message: JSON
   Output message: TTL
   """
   myMessage = pyDKB.dataflow.Message(pyDKB.dataflow.messageType.TTL)(msg.content())
-  return myMessage
+  stage.output(myMessage)
+  return True
 
 def main(args):
   stage = pyDKB.dataflow.stage.JSON2TTLProcessorStage()

--- a/Utils/Dataflow/test/pyDKB/json2TTL.py
+++ b/Utils/Dataflow/test/pyDKB/json2TTL.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+"""
+Stage 0XX: some json data to TTL & SPARQL
+"""
+
+import sys
+sys.path.append("../../")
+
+import pyDKB
+
+def process(msg):
+  """
+  Input message: JSON
+  Output message: TTL
+  """
+  myMessage = pyDKB.dataflow.Message(pyDKB.dataflow.messageType.TTL)(msg.content())
+  return myMessage
+
+def main(args):
+  stage = pyDKB.dataflow.stage.JSON2TTLProcessorStage()
+  stage.process = process
+
+  stage.parse_args(args)
+  stage.run()
+
+if __name__ == '__main__':
+  main(sys.argv[1:])


### PR DESCRIPTION
The implementation of output logic according to the command line parameters was implemented.

**Major changes**
1. AbstractProcessorStage.process() method changed:
- has became a static method with two parameters: `stage, message`
  ...to allow usage of the Processor Stage output() method from within the process() implementation
- must return True or False
  ...to indicate if the processing was successful or not. If the
  processing has failed, all the output messages are dropped

2. AbstractProcessorStage.stop() method added
- must be called after run() to finalize internal processes

3. Test stage `Dataflow/test/pyDKB` added
- to demonstrate how to use Processor Stage and test its functionality

**The logic**

Output messages are buffered in `__output_buffer` parameter, and pushed forward only when the input message processing finished successfully.

Output messages separator and end-of-process (EOP) marker for (s)treaming mode are hardcoded for now (`\n` and `\0` respectively), _but should be made confugurable later_. The separator for input messages is the same as for output messages for now _(but must be configured independently in the future)_.

In (f)ile mode output goes to files with the same basename as the original one but with another extention (it is determined by the output message type). The files will appear in the same directory, as the original ones, or in the directory specified with `--output-dir`.