### PR TITLE
Stage 018: PDFDownloader

### DIFF
--- a/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
+++ b/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
@@ -5,6 +5,7 @@ Stage 018: download PDF files from CDS and upload them to HDFS
 """
 
 import sys
+import os
 from urlparse import urlparse
 import subprocess
 
@@ -17,7 +18,8 @@ from pyDKB.common import hdfs, HDFSException
 
 def transfer(url, hdfs_name):
     """ Download file from given URL and upload to HDFS. """
-    cmd = ["./transferPDF.sh", url, hdfs_name]
+    base_dir = os.path.dirname(__file__)
+    cmd = [os.path.join(base_dir, "transferPDF.sh"), url, hdfs_name]
     try:
         sp = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                    stderr=subprocess.PIPE,

--- a/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
+++ b/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
@@ -33,8 +33,8 @@ def transfer(url, hdfs_name):
             out = out.strip()
         return out
     except (subprocess.CalledProcessError, OSError, HDFSException), err:
-        sys.stderr.write("Failed to transfer data from CDS to HDSF: %s\n"
-                         % err)
+        sys.stderr.write("(ERROR) Failed to transfer data from CDS to HDSF:"
+                         " %s\n" % err)
         return None
 
 def get_url(item):

--- a/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
+++ b/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
@@ -25,7 +25,7 @@ def transfer(url, hdfs_name):
                                    stderr=subprocess.PIPE,
                                    stdout=subprocess.PIPE)
         if hdfs.check_stderr(sp):
-            raise subprocess.CalledProcessError(proc.returncode, cmd)
+            raise subprocess.CalledProcessError(sp.returncode, cmd)
         out = sp.stdout.readline()
         if out:
             out = out.strip()

--- a/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
+++ b/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
@@ -48,8 +48,9 @@ def get_url(item):
         v = -1
         if url.split('.')[-1].lower() == "pdf" \
           and (desc == None or desc.lower().find("fulltext") >= 0):
-            if f.get('version') and f['version'] > v:
-                v = f['version']
+            if f.get('version', None) != None and f['version'] > v \
+              or v < 0:
+                v = f.get('version', v)
                 result = url
     return result
 

--- a/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
+++ b/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
@@ -9,6 +9,8 @@ import os
 from urlparse import urlparse
 import subprocess
 
+import traceback
+
 sys.path.append("../")
 
 import pyDKB
@@ -80,15 +82,26 @@ def main(args):
     stage.process = process
 
     exit_code = 0
+    exc_info = None
     try:
         stage.parse_args(args)
         stage.run()
     except (DataflowException, RuntimeError), err:
         if str(err):
             sys.stderr.write("(ERROR) %s\n" % err)
+        else:
+            exc_info = sys.exc_info()
+        exit_code = 2
+    except Exception:
+        exc_info = sys.exc_info()
         exit_code = 1
     finally:
         stage.stop()
+
+    if exc_info:
+        trace = traceback.format_exception(*exc_info)
+        for line in trace:
+            sys.stderr.write("(ERROR) %s" % line)
 
     exit(exit_code)
 

--- a/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
+++ b/Utils/Dataflow/018_PDFDownloader/getPDFfromCDS.py
@@ -44,7 +44,7 @@ def get_url(item):
         url = f.get('url')
         if not url:
             continue
-        desc = f.get('description', '')
+        desc = f.get('description', None)
         v = -1
         if url.split('.')[-1].lower() == "pdf" \
           and (desc == None or desc.lower().find("fulltext") >= 0):

--- a/Utils/Dataflow/018_PDFDownloader/kerberos_init.sh
+++ b/Utils/Dataflow/018_PDFDownloader/kerberos_init.sh
@@ -13,16 +13,18 @@ krb_init() {
     case $1 in
         cern)
             realm="CERN.CH"
+            def_user=`echo "$USER" | cut -c 1-8`
             ;;
         kiae)
             realm="HADOOP.NOSQL.KIAE.RU"
+            def_user=$USER
             ;;
         *)
             echo "Unknown realm: $1" >&2
     esac
 
-    read -p "Username ($realm) ($USER): " user
-    [ -z "$user" ] && user=$USER
+    read -p "Username ($realm) ($def_user): " user
+    [ -z "$user" ] && user=$def_user
 
     kinit -c "${KRB_TMP}/${KRB_TKT}.${1}" "$user"@"$realm"
 }

--- a/Utils/Dataflow/018_PDFDownloader/switch_realm
+++ b/Utils/Dataflow/018_PDFDownloader/switch_realm
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+KRB_KIAE=~/.krb5/krb5cc_$UID.kiae
+KRB_CERN=~/.krb5/krb5cc_$UID.cern
+switch_realm() {
+    # Switch Kerberos ticket to the given realm
+    [ -z "$1" ] && return 1
+    case $1 in
+        kiae)
+            TKT=$KRB_KIAE
+            ;;
+        cern)
+            TKT=$KRB_CERN
+            ;;
+        *)
+            echo "Unknown realm: $1" >&2
+            return 1
+            ;;
+    esac
+    export KRB5CCNAME="FILE:/$TKT"
+}

--- a/Utils/Dataflow/018_PDFDownloader/transferPDF.sh
+++ b/Utils/Dataflow/018_PDFDownloader/transferPDF.sh
@@ -83,4 +83,6 @@ fi
 local_file=`download $1` \
   && upload $local_file $2 2>/dev/null
 
+[ -f "$local_file" ] && rm $local_file
+
 exit $?

--- a/Utils/Dataflow/018_PDFDownloader/transferPDF.sh
+++ b/Utils/Dataflow/018_PDFDownloader/transferPDF.sh
@@ -7,8 +7,9 @@
 
 PID=$$
 HDFS_DIR="/user/DKB/store/PDF"
-KRB_KIAE=~/.krb5/krb5cc_$UID.kiae
-KRB_CERN=~/.krb5/krb5cc_$UID.cern
+base_dir=`dirname $0`
+
+. $base_dir/switch_realm
 
 usage() {
     echo "
@@ -21,23 +22,6 @@ PARAMETERS:
 " >&2
 }
 
-switch_realm() {
-    # Switch Kerberos ticket to the given realm
-    [ -z "$1" ] && return 1
-    case $1 in
-        kiae)
-            TKT=$KRB_KIAE
-            ;;
-        cern)
-            TKT=$KRB_CERN
-            ;;
-        *)
-            echo "Unknown realm: $1" >&2
-            return 1
-            ;;
-    esac
-    export KRB5CCNAME="FILE:/$TKT"
-}
 
 upload() {
     # Upload file to HDFS

--- a/Utils/Dataflow/018_PDFDownloader/transferPDF.sh
+++ b/Utils/Dataflow/018_PDFDownloader/transferPDF.sh
@@ -29,7 +29,10 @@ upload() {
     switch_realm kiae || return $?
     [ -z "$2" ] && hdfs_file=$HDFS_DIR/`basename $1` || hdfs_file=$HDFS_DIR/$2
     hadoop fs -put -f $1 $HDFS_DIR/$2
-    echo $hdfs_file
+    ret=$?
+    [ $ret -eq 0 ] && export hdfs_file
+    rm -f $1
+    exit $ret
 }
 
 
@@ -41,14 +44,15 @@ download() {
     cookie=/tmp/cern-sso-cookie-$PID
     tmpf=`mktemp /tmp/XXXXXXX.pdf`
 
-    cern-get-sso-cookie --krb -r -u "$url" -o $cookie 2>&1 >/dev/null
+    cern-get-sso-cookie --krb -r -u "$url" -o $cookie
 
     if [ $? -ne 0 ]; then
         echo "Failed to get CERN SSO cookie." >&2
         exit 3
     fi
 
-    curl -k -L -f -s  --cookie $cookie --cookie-jar $cookie $url -o $tmpf && echo $tmpf
+    curl -k -L -f -s  --cookie $cookie --cookie-jar $cookie $url -o $tmpf || tmpf=
+    export local_file=$tmpf
 }
 
 which cern-get-sso-cookie 2>&1 >/dev/null
@@ -64,9 +68,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-local_file=`download $1` \
-  && upload $local_file $2 2>/dev/null
 
-[ -f "$local_file" ] && rm $local_file
+download $1 >&2 \
+  && upload $local_file $2 >&2
 
-exit $?
+ret=$?
+
+echo "$hdfs_file"
+
+exit $ret


### PR DESCRIPTION
Main changes:
* stage learned how to remove temporary files after itself;
* switch_realm moved to a separate file (as it is useful not only for this stage);
* stage dies on failure after 3 retries;

Minor fixes:
* wrong varname;
* PDF document choise by version;
* relative filename issue;
* wrong log message format;
* STDERR and STDOUT in `transferPDF.sh`
* more precise username definition in `kerberos_init.sh`