### PR TITLE
DF/kafka: modify Streams timing to log Thread name as well.

### DIFF
--- a/Utils/Dataflow/000_kafka/ru/kiae/dkb/kafka/streams/processor/external/ExternalProcessorSupplier.java
+++ b/Utils/Dataflow/000_kafka/ru/kiae/dkb/kafka/streams/processor/external/ExternalProcessorSupplier.java
@@ -145,8 +145,8 @@ public class ExternalProcessorSupplier implements ProcessorSupplier<String, Stri
               }
               if (! retried) {
                   time += new Date().getTime() - start;
-                  timing.info("({}) Message processing took: {} ms", externalCommand[0], time);
-                  timing.info("({}) Full processing took: {} ms", externalCommand[0], new Date().getTime() - processing_start);
+                  timing.info("({}) Message processing took: {} ms ({})", externalCommand[0], time, Thread.currentThread().getName());
+                  timing.info("({}) Full processing took: {} ms ({})", externalCommand[0], new Date().getTime() - processing_start, Thread.currentThread().getName());
               }
             }
 


### PR DESCRIPTION
As without understanding, what process belongs to what thread, we can analyze the timing only "as is", but can`t reconstruct the full chain of timings for a single record from the initial source.