### PR TITLE
Travis: update codestyle checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - pip install pep8
 
 script:
-    - errors=`find . -name "*.py" -exec pep8 --select E121,E122,E126,E128,E203,E225,E226,E228,E231,E251,E261,E262,E265,E266,W291,W293,E502 {} \; `
+    - errors=`find . -name "*.py" -exec pep8 --ignore W503,W292 {} \; `
     - num_errors=`echo -n "$errors" | wc -l`
     - |
         if [ $num_errors -eq 0 ]; then

--- a/Utils/Dataflow/009_oracleConnector/DButils.py
+++ b/Utils/Dataflow/009_oracleConnector/DButils.py
@@ -58,7 +58,8 @@ def OneByOneIter(connection, query, rows_as_dict=False):
     https://bitbucket.org/anthony_tuininga/cx_oracle/issues/49/lob-object-documentation-clarification
     :param connection: Oracle connection
     :param query: query steing
-    :param rows_as_dict: return rows with headers as dicts (True), or as lists (False)
+    :param rows_as_dict: return rows with headers as dicts (True),
+                         or as lists (False)
     :return:
     """
     cursor = connection.cursor()

--- a/Utils/Dataflow/009_oracleConnector/DButils.py
+++ b/Utils/Dataflow/009_oracleConnector/DButils.py
@@ -12,11 +12,13 @@ except:
     print "****ERROR : DButils. Cannot import cx_Oracle"
     pass
 
+
 def connectDEFT_DSN(dsn):
     connect = cx_Oracle.connect(dsn)
     cursor = connect.cursor()
 
     return connect, cursor
+
 
 def connectDEFT(dbname, dbuser, pwd):
     connect = cx_Oracle.connect(dbuser, pwd, dbname)
@@ -73,6 +75,7 @@ def OneByOneIter(connection, query, rows_as_dict=False):
         else:
             yield row
 
+
 def fix_lob(row):
     """
     This procedure is needed in case of using
@@ -106,6 +109,7 @@ def QueryAll(connection, query):
 
     return dbrows
 
+
 def QueryToCSV(connection, query, filename, arraysize=100):
     cursor = connection.cursor()
     cursor.execute(query)
@@ -120,6 +124,7 @@ def QueryToCSV(connection, query, filename, arraysize=100):
                 row = fix_lob(row)
                 writer.writerow(row)
 
+
 def CSV2JSON(csv_file, json_file):
     csv_file_handler = open(csv_file, 'r')
     json_file_handler = open(json_file, 'w')
@@ -130,6 +135,7 @@ def CSV2JSON(csv_file, json_file):
         json_file_handler.write(',')
         json_file_handler.write('\n')
     json_file_handler.write(']')
+
 
 def QueryUpdate(connection, query):
     error = 0

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -208,7 +208,7 @@ def interval_seconds(step):
         pass
     if len(step) < 2:
         raise ValueError("Failed to decode interval: %s" % step)
-    suffix = { 'd': 86400, 'h': 3600, 'm': 60, 's': 1}
+    suffix = {'d': 86400, 'h': 3600, 'm': 60, 's': 1}
     val = step[:-1]
     try:
         mul = suffix[step[-1]]
@@ -304,10 +304,10 @@ def parsingArguments():
     if not os.access(args.config, os.F_OK):
         sys.stderr.write("argument --config: '%s' file not exists\n" % args.config)
         sys.exit(1)
-    if not os.access(args.config, os.R_OK|os.W_OK):
+    if not os.access(args.config, os.R_OK | os.W_OK):
         sys.stderr.write("argument --config: '%s' read/write access failed\n" % args.config)
         sys.exit(1)
     return parser.parse_args()
 
-if  __name__ == '__main__':
+if __name__ == '__main__':
     main()

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -78,14 +78,17 @@ def main():
 
 
 def plain(conn, queries, offset_date, end_date):
-    tasks = query_executor(conn, queries['tasks']['file'], offset_date, end_date)
+    tasks = query_executor(conn, queries['tasks']['file'], offset_date,
+                           end_date)
     for task in tasks:
         yield task
 
 
 def squash(conn, queries, offset_date, end_date):
-    tasks = query_executor(conn, queries['tasks']['file'], offset_date, end_date)
-    datasets = query_executor(conn, queries['datasets']['file'], offset_date, end_date)
+    tasks = query_executor(conn, queries['tasks']['file'], offset_date,
+                           end_date)
+    datasets = query_executor(conn, queries['datasets']['file'], offset_date,
+                              end_date)
     return join_results(tasks, squash_records(datasets))
 
 
@@ -171,7 +174,8 @@ def query_executor(conn, sql_file, offset_date, end_date):
     """
     try:
         file_handler = open(sql_file)
-        query = file_handler.read().rstrip().rstrip(';') % (offset_date, end_date)
+        query = file_handler.read().rstrip().rstrip(';') % (offset_date,
+                                                            end_date)
         return DButils.ResultIter(conn, query, 1000, True)
     except IOError:
         sys.stderr.write('File open error. No such file (%s).\n' % sql_file)
@@ -234,7 +238,8 @@ def get_category(row):
     """
     Each task can be associated with a number of Physics Categories.
     1) search category in hashtags list
-    2) if not found in hashtags, then search category in phys_short field of tasknames
+    2) if not found in hashtags, then search category in phys_short
+       field of tasknames
     :param row
     :return:
     """
@@ -268,9 +273,11 @@ def get_category(row):
     match = {}
     categories = []
     for phys_category in PHYS_CATEGORIES_MAP:
-        current_map = [x.strip(' ').lower() for x in PHYS_CATEGORIES_MAP[phys_category]]
+        current_map = [x.strip(' ').lower()
+                       for x in PHYS_CATEGORIES_MAP[phys_category]]
         if hashtags is not None:
-            match[phys_category] = len([x for x in hashtags.lower().split(',') if x.strip(' ') in current_map])
+            match[phys_category] = len([x for x in hashtags.lower().split(',')
+                                        if x.strip(' ') in current_map])
     categories = [cat for cat in match if match[cat] > 0]
     if not categories and taskname:
         phys_short = taskname.split('.')[2].lower()
@@ -310,17 +317,20 @@ def get_category(row):
 
 
 def parsingArguments():
-    parser = argparse.ArgumentParser(description='Process command line arguments.')
+    parser = argparse.ArgumentParser(description='Process command line
+                                     arguments.')
     parser.add_argument('--config', help='Configuration file path',
                         type=str, required=True)
     parser.add_argument('--mode', help='Mode of execution: PLAIN | SQUASH',
                         choices=[PLAIN_POLICY, SQUASH_POLICY])
     args = parser.parse_args()
     if not os.access(args.config, os.F_OK):
-        sys.stderr.write("argument --config: '%s' file not exists\n" % args.config)
+        sys.stderr.write("argument --config: '%s' file not exists\n"
+                         % args.config)
         sys.exit(1)
     if not os.access(args.config, os.R_OK | os.W_OK):
-        sys.stderr.write("argument --config: '%s' read/write access failed\n" % args.config)
+        sys.stderr.write("argument --config: '%s' read/write access failed\n"
+                         % args.config)
         sys.exit(1)
     return parser.parse_args()
 

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -19,6 +19,7 @@ except:
 PLAIN_POLICY = 'PLAIN'
 SQUASH_POLICY = 'SQUASH'
 
+
 def connectDEFT_DSN(dsn):
     try:
         connect = cx_Oracle.connect(dsn)
@@ -27,6 +28,7 @@ def connectDEFT_DSN(dsn):
         return None
 
     return connect
+
 
 def main():
     """
@@ -85,6 +87,7 @@ def squash(conn, queries, offset_date, end_date):
     tasks = query_executor(conn, queries['tasks']['file'], offset_date, end_date)
     datasets = query_executor(conn, queries['datasets']['file'], offset_date, end_date)
     return join_results(tasks, squash_records(datasets))
+
 
 def squash_records(rec):
     """
@@ -161,6 +164,7 @@ def process(conn, offset_date, final_date_cfg, step_seconds, queries):
         if not final_date_cfg:
             final_date = date2str(datetime.now())
 
+
 def query_executor(conn, sql_file, offset_date, end_date):
     """
     Execution of query with offset from file
@@ -179,6 +183,7 @@ def get_offset():
     config.read(conf)
     return config.get("timestamps", "offset")
 
+
 def update_offset(new_offset):
     """
     Updating offset value in configuration file
@@ -189,6 +194,7 @@ def update_offset(new_offset):
     config.set('timestamps', 'offset', new_offset)
     with open(conf, 'w') as configfile:
         config.write(configfile)
+
 
 def interval_seconds(step):
     """
@@ -213,13 +219,16 @@ def interval_seconds(step):
     except KeyError:
         raise ValueError("Failes to decode index of the interval: %s" % step)
 
+
 def str2date(str_date):
     """ Convert string (%d-%m-%Y %H:%M:%S) to datetime object. """
     return datetime.strptime(str_date, "%d-%m-%Y %H:%M:%S")
 
+
 def date2str(date):
     """ Convert datetime object to string (%d-%m-%Y %H:%M:%S). """
     return datetime.strftime(date, "%d-%m-%Y %H:%M:%S")
+
 
 def get_category(row):
     """
@@ -283,6 +292,7 @@ def get_category(row):
     if not categories:
         categories = ["Uncategorized"]
     return categories
+
 
 def parsingArguments():
     parser = argparse.ArgumentParser(description='Process command line arguments.')

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -274,21 +274,36 @@ def get_category(row):
     categories = [cat for cat in match if match[cat] > 0]
     if not categories and taskname:
         phys_short = taskname.split('.')[2].lower()
-        if re.search('singletop', phys_short) is not None: categories.append("SingleTop")
-        if re.search('ttbar', phys_short) is not None: categories.append("TTbar")
-        if re.search('jets', phys_short) is not None: categories.append("Multijet")
-        if re.search('h125', phys_short) is not None: categories.append("Higgs")
-        if re.search('ttbb', phys_short) is not None: categories.append("TTbarX")
-        if re.search('ttgamma', phys_short) is not None: categories.append("TTbarX")
-        if re.search('_tt_', phys_short) is not None: categories.append("TTbar")
-        if re.search('upsilon', phys_short) is not None: categories.append("BPhysics")
-        if re.search('tanb', phys_short) is not None: categories.append("SUSY")
-        if re.search('4topci', phys_short) is not None: categories.append("Exotic")
-        if re.search('xhh', phys_short) is not None: categories.append("Higgs")
-        if re.search('3top', phys_short) is not None: categories.append("TTbarX")
-        if re.search('_wt', phys_short) is not None: categories.append("SingleTop")
-        if re.search('_wwbb', phys_short) is not None: categories.append("SingleTop")
-        if re.search('_wenu_', phys_short) is not None: categories.append("Wjets")
+        if re.search('singletop', phys_short) is not None:
+            categories.append("SingleTop")
+        if re.search('ttbar', phys_short) is not None:
+            categories.append("TTbar")
+        if re.search('jets', phys_short) is not None:
+            categories.append("Multijet")
+        if re.search('h125', phys_short) is not None:
+            categories.append("Higgs")
+        if re.search('ttbb', phys_short) is not None:
+            categories.append("TTbarX")
+        if re.search('ttgamma', phys_short) is not None:
+            categories.append("TTbarX")
+        if re.search('_tt_', phys_short) is not None:
+            categories.append("TTbar")
+        if re.search('upsilon', phys_short) is not None:
+            categories.append("BPhysics")
+        if re.search('tanb', phys_short) is not None:
+            categories.append("SUSY")
+        if re.search('4topci', phys_short) is not None:
+            categories.append("Exotic")
+        if re.search('xhh', phys_short) is not None:
+            categories.append("Higgs")
+        if re.search('3top', phys_short) is not None:
+            categories.append("TTbarX")
+        if re.search('_wt', phys_short) is not None:
+            categories.append("SingleTop")
+        if re.search('_wwbb', phys_short) is not None:
+            categories.append("SingleTop")
+        if re.search('_wenu_', phys_short) is not None:
+            categories.append("Wjets")
     if not categories:
         categories = ["Uncategorized"]
     return categories

--- a/Utils/Dataflow/pyDKB/dataflow/cds.py
+++ b/Utils/Dataflow/pyDKB/dataflow/cds.py
@@ -65,7 +65,6 @@ else:
             self.delete()
             os.kill(os.getpid(), signum)
 
-
     class KerberizedCDSInvenioConnector(CDSInvenioConnector):
         """
         Represents same CDSInvenioConnector, but this one is aware about

--- a/Utils/Dataflow/pyDKB/dataflow/cds.py
+++ b/Utils/Dataflow/pyDKB/dataflow/cds.py
@@ -31,7 +31,7 @@ else:
 
         def __init__(self, *args):
             self.orig_handlers = {
-                signal.SIGINT:  signal.signal(signal.SIGINT, self.kill),
+                signal.SIGINT: signal.signal(signal.SIGINT, self.kill),
                 signal.SIGTERM: signal.signal(signal.SIGTERM, self.kill)
             }
             handlers = True


### PR DESCRIPTION
Change PEP8 codestyle checks.
Since now the only ignored by `pep8` (https://pypi.python.org/pypi/pep8) codes are:
* W503 (line break before binary operator):
  https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
* W292 (no newline in the end of file):
  as we work in different OSs, it might be a problem

If there are any other codes that you think must be ignored, please write it in the comments..