### PR TITLE
Travis: pep8 checks update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ jobs:
       language: python
       python: 2.7
       before_install:
-        - pip install pep8
+        - pip install pycodestyle
 
       script:
-        - errors=`find . -name "*.py" -exec pep8 --ignore W503,W292 {} \; `
+        - errors=`find . -name "*.py" -exec pycodestyle --ignore W503,W292 {} \; `
         - num_errors=`echo -n "$errors" | wc -l`
         - |
             if [ $num_errors -eq 0 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ jobs:
         - num_errors=`echo -n "$errors" | wc -l`
         - |
             if [ $num_errors -eq 0 ]; then
-              true 
+              true
             else
               echo "$errors"
-              false 
+              false
             fi
 
     - stage: python_check
@@ -28,8 +28,8 @@ jobs:
         - errors=`find . -name "*.py" -exec python -m py_compile {} \; 2>&1`
         - |
             if [ -z "$errors" ]; then
-              true 
+              true
             else
               echo "$errors"
-              false 
+              false
             fi

--- a/Utils/DataFromAMI/getDataPeriods_AMI.py
+++ b/Utils/DataFromAMI/getDataPeriods_AMI.py
@@ -34,7 +34,7 @@ for year in range(year_start, year_end):
             result = AtlasAPI.list_dataperiods(client, level=level, year=year)
             tmp.append(",".join(str(json.dumps(item, indent=4))
                                 for item in result))
-        except:
+        except pyAMI.exception.Error:
             print "No periods found!"
 f.write("[" + ",".join(str(x) for x in tmp) + "]")
 f.close()

--- a/Utils/DataFromAMI/getRunNumbersFromAMI.py
+++ b/Utils/DataFromAMI/getRunNumbersFromAMI.py
@@ -28,7 +28,7 @@ for item in json_content:
             client, year=int(year), data_periods=period)
         tmp.append(",".join(str(json.dumps(item, indent=4))
                             for item in result))
-    except:
+    except pyAMI.exception.Error:
         print "Cannot find results for period = " + str(period)
 
 runs_file.write("[" + ",".join(str(x) for x in tmp) + "]")

--- a/Utils/Dataflow/030_PDFAnalyzer/manager.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/manager.py
@@ -546,71 +546,10 @@ class Paper:
     def delete(self):
         """ Delete all files associated with paper. """
         shutil.rmtree(self.dir)
-# def find_title(self):
-# """ New title determining method, does not works ideally yet.
-# Titles consisting of several lines are problematic to
-# determine.
-# """
-#        lines = self.get_xml_page(1)
-#
-#        d = {}
-# for l in lines:
-#            m = re_xml_symbol.match(l)
-# if m:
-#                size = float(m.group(1))
-#                text = m.group(2)
-# if size in d.keys():
-#                    d[size] += text
-# else:
-#                    d[size] = text
-# elif re_xml_empty_symbol.match(l):
-#                d[size] += " "
-#        xml_title = False
-# print d
-# while True:
-#            size = max(d.keys())
-#            valid = True
-# try:
-# d[size].decode()
-# except:
-#                valid = False
-# if not "atlas note" in d[size].lower() and valid:
-#                xml_title = d[size]
-# break
-# else:
-#                del d[size]
-#
-# print xml_title
-# if not xml_title:
-# return False
-#
-#        lines = self.get_txt_page(1)
-#        title = ""
-# for l in lines:
-# if len(l) <= 4 or l.startswith("Supporting Note")\
-# or l.startswith("ATLAS NOTE"):
-# continue
-#            words = l.split()
-#            i = 0
-# for w in words:
-# try:
-# This throws exception sometimes, something about
-# ascii codec unable to decode.
-#                    w_in = w in xml_title
-# except:
-#                    w_in = False
-# if len(w) > 1 and w_in:
-#                    i += 1
-# if i > 1 or (len(words) == 1 and i == 1):
-#                title += l.replace("\n", " ")
-# elif title:
-# break
-# return title
 
     def find_attributes_general(self):
         """ Find general attributes in a document. """
         attrs = {}
-#        attrs["title"] = self.find_title()
         text = self.get_text()
 
         attrs["campaigns"] = []

--- a/Utils/Dataflow/030_PDFAnalyzer/manager.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/manager.py
@@ -67,8 +67,7 @@ def path_join(a, b):
 if __name__ == "__main__":
     try:
         import Tkinter
-        from tkFileDialog import askdirectory, askopenfilename,\
-            askopenfilenames, asksaveasfile
+        from tkFileDialog import askdirectory, askopenfilenames, asksaveasfile
         import tkMessageBox
     except Exception as e:
         sys.stderr.write("Exception while loading Tkinter: %s\n" % e)

--- a/Utils/Dataflow/030_PDFAnalyzer/manager.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/manager.py
@@ -391,24 +391,24 @@ def process_diapason(d):
     return values
 
 
-def check_all_button(v, l):
+def check_all_button(v, lst):
     """ Command for handling Tkinter global checkbuttons.
 
     Command (un)checks all the checkbuttons in the list
     v - a VarInt variable associated with the global checkbutton.
-    l - a list of VarInt variables associated with checkbuttons in the
+    lst - a list of VarInt variables associated with checkbuttons in the
     list.
     """
     s = 0
-    for i in l:
+    for i in lst:
         s += i.get()
-    if s == len(l):
+    if s == len(lst):
         v.set(0)
-        for i in l:
+        for i in lst:
             i.set(0)
     else:
         v.set(1)
-        for i in l:
+        for i in lst:
             i.set(1)
 
 
@@ -933,8 +933,8 @@ class Manager:
                      self.show_paper_info(False, paper))
             b.grid(row=r, column=0)
             if p.title is not None:
-                l = Tkinter.Label(self.frame, text=p.title)
-                l.grid(row=r, column=1)
+                lbl = Tkinter.Label(self.frame, text=p.title)
+                lbl.grid(row=r, column=1)
             r += 1
 
         self.frame.update_idletasks()
@@ -960,29 +960,29 @@ class Manager:
 
         frame = Tkinter.Frame(w)
 
-        l = Tkinter.Label(frame, text="Working directory")
-        l.grid(row=0, column=0)
+        lbl = Tkinter.Label(frame, text="Working directory")
+        lbl.grid(row=0, column=0)
         e = Tkinter.Entry(frame, width=100, textvariable=work_dir)
         e.grid(row=0, column=1)
 
-        l = Tkinter.Label(frame, text="Determine papers' titles")
-        l.grid(row=1, column=0)
+        lbl = Tkinter.Label(frame, text="Determine papers' titles")
+        lbl.grid(row=1, column=0)
         b = Tkinter.Checkbutton(frame, variable=determine_title)
         b.grid(row=1, column=1)
 
-        l = Tkinter.Label(frame, text="Open intervals in text")
-        l.grid(row=2, column=0)
+        lbl = Tkinter.Label(frame, text="Open intervals in text")
+        lbl.grid(row=2, column=0)
         b = Tkinter.Checkbutton(frame, variable=open_intervals_text)
         b.grid(row=2, column=1)
 
-        l = Tkinter.Label(frame, text="Open intervals in tables")
-        l.grid(row=3, column=0)
+        lbl = Tkinter.Label(frame, text="Open intervals in tables")
+        lbl.grid(row=3, column=0)
         b = Tkinter.Checkbutton(frame, variable=open_intervals_tables)
         b.grid(row=3, column=1)
 
         txt = "Extract dataset IDs instead of full tables"
-        l = Tkinter.Label(frame, text=txt)
-        l.grid(row=4, column=0)
+        lbl = Tkinter.Label(frame, text=txt)
+        lbl.grid(row=4, column=0)
         b = Tkinter.Checkbutton(frame, variable=tables_ids_only)
         b.grid(row=4, column=1)
 
@@ -1120,8 +1120,8 @@ class Manager:
             for c in window.winfo_children():
                 c.destroy()
         window.title("Info: %s" % paper.fname)
-        l = Tkinter.Label(window, text="File name: %s" % paper.fname)
-        l.grid(row=0, column=1)
+        lbl = Tkinter.Label(window, text="File name: %s" % paper.fname)
+        lbl.grid(row=0, column=1)
         b = Tkinter.Button(window, text="Save",
                            command=lambda paper=paper: self.save_paper(paper))
         b.grid(row=0, column=2)
@@ -1135,13 +1135,13 @@ class Manager:
         b = Tkinter.Button(window, text="Delete", command=lambda window=window,
                            paper=paper: self.delete_paper(window, paper))
         b.grid(row=0, column=5)
-        l = Tkinter.Label(window, text="Title: %s" % paper.title)
-        l.grid(row=1, columnspan=5)
-        l = Tkinter.Label(window, text="Pages: %d" % paper.num_pages)
-        l.grid(row=2, columnspan=5)
-        l = Tkinter.Label(window,
-                          text="Rotated pages: %s" % str(paper.rotated_pages))
-        l.grid(row=3, columnspan=5)
+        lbl = Tkinter.Label(window, text="Title: %s" % paper.title)
+        lbl.grid(row=1, columnspan=5)
+        lbl = Tkinter.Label(window, text="Pages: %d" % paper.num_pages)
+        lbl.grid(row=2, columnspan=5)
+        lbl = Tkinter.Label(window, text="Rotated pages: %s" %
+                            str(paper.rotated_pages))
+        lbl.grid(row=3, columnspan=5)
         b = Tkinter.Button(window, text="Attributes",
                            command=lambda window=window,
                            paper=paper: self.show_paper_attributes(window,
@@ -1187,8 +1187,8 @@ class Manager:
         d = {}
         r = re.compile("^<text[^>]+ size=\"([0-9.]+)\">(.+)</text>$")
         empty = re.compile("^<text> </text>$")
-        for l in lines:
-            m = r.match(l)
+        for line in lines:
+            m = r.match(line)
             if m:
                 size = m.group(1)
                 text = m.group(2)
@@ -1196,12 +1196,12 @@ class Manager:
                     d[size] += text
                 else:
                     d[size] = text
-            elif empty.match(l):
+            elif empty.match(line):
                 d[size] += " "
 
         msg = "Please, select a string which looks like a title of the paper"
-        l = Tkinter.Label(window, text=msg, font=HEADING_FONT)
-        l.grid(row=0, columnspan=2)
+        lbl = Tkinter.Label(window, text=msg, font=HEADING_FONT)
+        lbl.grid(row=0, columnspan=2)
         r = 1
         selection = Tkinter.StringVar()
         for key in d:
@@ -1237,11 +1237,11 @@ class Manager:
         possible_title = possible_title_variable.get()
 
         title = ""
-        for l in lines:
-            if len(l) <= 4 or l.startswith("Supporting Note")\
-               or l.startswith("ATLAS NOTE"):
+        for line in lines:
+            if len(line) <= 4 or line.startswith("Supporting Note")\
+               or line.startswith("ATLAS NOTE"):
                 continue
-            words = l.split()
+            words = line.split()
             i = 0
             for w in words:
                 try:
@@ -1253,12 +1253,13 @@ class Manager:
                 if len(w) > 1 and w_in:
                     i += 1
             if i > 1 or (len(words) == 1 and i == 1):
-                title += l.replace("\n", " ")
+                title += line.replace("\n", " ")
             elif title:
                 break
-        l = Tkinter.Label(window, text="Please, correct the title, if needed.",
-                          font=HEADING_FONT)
-        l.grid(row=0, columnspan=2)
+        lbl = Tkinter.Label(window,
+                            text="Please, correct the title, if needed.",
+                            font=HEADING_FONT)
+        lbl.grid(row=0, columnspan=2)
         e = Tkinter.Entry(window, width=150)
         e.insert(0, title)
         e.grid(row=1, columnspan=2)
@@ -1328,22 +1329,22 @@ class Manager:
             for a in paper.attributes_general:
                 if a == "links":
                     if paper.__dict__[a]:
-                        l = Tkinter.Label(window, text="Links:")
-                        l.grid(row=r, column=0)
+                        lbl = Tkinter.Label(window, text="Links:")
+                        lbl.grid(row=r, column=0)
                         r += 1
                         for key in paper.__dict__[a]:
                             txt = "%s %s" % (key, paper.__dict__[a][key])
-                            l = Tkinter.Label(window, text=txt)
-                            l.grid(row=r, column=0)
+                            lbl = Tkinter.Label(window, text=txt)
+                            lbl.grid(row=r, column=0)
                             r += 1
                     else:
-                        l = Tkinter.Label(window, text="No links")
-                        l.grid(row=r, column=0)
+                        lbl = Tkinter.Label(window, text="No links")
+                        lbl.grid(row=r, column=0)
                         r += 1
                 else:
                     txt = "%s:%s" % (a, str(paper.__dict__[a]))
-                    l = Tkinter.Label(window, text=txt)
-                    l.grid(row=r, column=0)
+                    lbl = Tkinter.Label(window, text=txt)
+                    lbl.grid(row=r, column=0)
                     r += 1
             b = Tkinter.Button(window, text="Back",
                                command=lambda window=window,
@@ -1369,8 +1370,8 @@ class Manager:
                 r = 0
                 dataset_entries = {}
                 for c in datasets:
-                    l = Tkinter.Label(frame, text=c, font=HEADING_FONT)
-                    l.grid(row=r, column=0, columnspan=2)
+                    lbl = Tkinter.Label(frame, text=c, font=HEADING_FONT)
+                    lbl.grid(row=r, column=0, columnspan=2)
                     c_s = Tkinter.IntVar()
                     c_s.set(1)
                     check_category_b = Tkinter.Checkbutton(frame, var=c_s)
@@ -1380,8 +1381,8 @@ class Manager:
                     selected_list = []
                     datasets[c].sort(key=lambda d: d[0])
                     for [name, special] in datasets[c]:
-                        l = Tkinter.Label(frame, text=special)
-                        l.grid(row=r, column=0)
+                        lbl = Tkinter.Label(frame, text=special)
+                        lbl.grid(row=r, column=0)
                         e = Tkinter.Entry(frame, width=150)
                         e.insert(0, name)
                         e.grid(row=r, column=1)
@@ -1397,8 +1398,8 @@ class Manager:
                     # checkbuttons are clicked - therefore, global
                     # checkbox will not change its look.
                     check_category_b.config(command=lambda v=c_s,
-                                            l=selected_list:
-                                            check_all_button(v, l))
+                                            lst=selected_list:
+                                            check_all_button(v, lst))
 
                 scrlbr = Tkinter.Scrollbar(window, command=cnvs.yview)
                 scrlbr.grid(row=0, column=2, rowspan=2, sticky='ns')
@@ -1425,9 +1426,9 @@ class Manager:
                                             datasets)
         else:
             if not paper.datasets:
-                l = Tkinter.Label(window, text="No datasets found",
-                                  font=HEADING_FONT)
-                l.grid(row=0)
+                lbl = Tkinter.Label(window, text="No datasets found",
+                                    font=HEADING_FONT)
+                lbl.grid(row=0)
             else:
                 cnvs = Tkinter.Canvas(window, width=1200, height=800)
                 cnvs.grid(row=0, column=0, columnspan=2)
@@ -1437,13 +1438,13 @@ class Manager:
 
                 r = 0
                 for k in paper.datasets:
-                    l = Tkinter.Label(frame, text=k, font=HEADING_FONT)
-                    l.grid(row=r)
+                    lbl = Tkinter.Label(frame, text=k, font=HEADING_FONT)
+                    lbl.grid(row=r)
                     r += 1
 #                    for [d, special] in paper.datasets[k]:
                     for d in paper.datasets[k]:
-                        l = Tkinter.Label(frame, text=d)
-                        l.grid(row=r)
+                        lbl = Tkinter.Label(frame, text=d)
+                        lbl.grid(row=r)
                         r += 1
 
                 scrlbr = Tkinter.Scrollbar(window, command=cnvs.yview)
@@ -1482,10 +1483,11 @@ class Manager:
                     t_frame = Tkinter.Frame(frame)
                     selected = Tkinter.IntVar()
                     selected.set(1)
-                    l = Tkinter.Label(t_frame, text=header, font=HEADING_FONT)
+                    lbl = Tkinter.Label(t_frame, text=header,
+                                        font=HEADING_FONT)
                     b = Tkinter.Checkbutton(t_frame, var=selected)
                     if isinstance(data, str) or isinstance(data, unicode):
-                        l.grid(row=0, column=0)
+                        lbl.grid(row=0, column=0)
                         b.grid(row=0, column=1)
                         t = Tkinter.Text(t_frame, width=(6 + 1) * 5,
                                          height=data.count(" ") // 5 + 2)
@@ -1494,21 +1496,21 @@ class Manager:
                         datatables_s.append([k, header, t, selected])
                     else:
                         rows = data
-                        l.grid(row=0, column=0, columnspan=len(rows[0]))
+                        lbl.grid(row=0, column=0, columnspan=len(rows[0]))
                         b.grid(row=0, column=len(rows[0]))
                         r = 1
                         for row in rows:
                             c = 0
                             for line in row:
-                                l = Tkinter.Label(t_frame, text=line)
-                                l.grid(row=r, column=c)
+                                lbl = Tkinter.Label(t_frame, text=line)
+                                lbl.grid(row=r, column=c)
                                 c += 1
                             r += 1
                             if r == 50:
                                 msg = "Table is too large, "\
                                       "omitting remaining rows."
-                                l = Tkinter.Label(t_frame, text=msg)
-                                l.grid(row=r, columnspan=c)
+                                lbl = Tkinter.Label(t_frame, text=msg)
+                                lbl.grid(row=r, columnspan=c)
                                 break
                         datatables_s.append([k, header, rows, selected])
                     t_frame.grid(row=num, column=0)
@@ -1540,9 +1542,9 @@ class Manager:
                                             datatables)
         else:
             if not paper.datatables:
-                l = Tkinter.Label(window, text="No datatables found",
-                                  font=HEADING_FONT)
-                l.grid(row=0)
+                lbl = Tkinter.Label(window, text="No datatables found",
+                                    font=HEADING_FONT)
+                lbl.grid(row=0)
                 r = 1
             else:
                 cnvs = Tkinter.Canvas(window, width=1200, height=800)
@@ -1557,27 +1559,28 @@ class Manager:
                 for k in keys:
                     (header, data) = paper.datatables[k]
                     t_frame = Tkinter.Frame(frame)
-                    l = Tkinter.Label(t_frame, text=header, font=HEADING_FONT)
+                    lbl = Tkinter.Label(t_frame, text=header,
+                                        font=HEADING_FONT)
                     if isinstance(data, str) or isinstance(data, unicode):
-                        l.grid(row=0, column=0)
-                        l = Tkinter.Label(t_frame, text=data, wraplength=600)
-                        l.grid(row=1, column=0)
+                        lbl.grid(row=0, column=0)
+                        lbl = Tkinter.Label(t_frame, text=data, wraplength=600)
+                        lbl.grid(row=1, column=0)
                     else:
                         rows = data
-                        l.grid(row=0, column=0, columnspan=len(rows[0]))
+                        lbl.grid(row=0, column=0, columnspan=len(rows[0]))
                         r = 1
                         for row in rows:
                             c = 0
                             for line in row:
-                                l = Tkinter.Label(t_frame, text=line)
-                                l.grid(row=r, column=c)
+                                lbl = Tkinter.Label(t_frame, text=line)
+                                lbl.grid(row=r, column=c)
                                 c += 1
                             r += 1
                             if r == 50:
                                 msg = "Table is too large, "\
                                       "omitting remaining rows."
-                                l = Tkinter.Label(t_frame, text=msg)
-                                l.grid(row=r, columnspan=c)
+                                lbl = Tkinter.Label(t_frame, text=msg)
+                                lbl.grid(row=r, columnspan=c)
                                 break
                     t_frame.grid(row=num, column=0)
                     num += 1
@@ -1602,9 +1605,9 @@ class Manager:
             for c in window.winfo_children():
                 c.destroy()
             window.title("Select page")
-            l = Tkinter.Label(window, text="Page number(1 - %d):"
-                              % paper.num_pages)
-            l.grid(row=0, column=0)
+            lbl = Tkinter.Label(window, text="Page number(1 - %d):"
+                                % paper.num_pages)
+            lbl.grid(row=0, column=0)
             e = Tkinter.Entry(window, width=10)
             e.grid(row=0, column=1)
             e.focus_set()
@@ -1631,23 +1634,23 @@ class Manager:
                 tables = xmltable.get_tables_from_text(text)
                 for table_num in range(0, len(tables)):
                     frame = Tkinter.Frame(window)
-                    l = Tkinter.Label(frame, text="Table %d" % table_num)
-                    l.grid(row=0, column=0,
-                           columnspan=len(tables[table_num].rows[0]))
+                    lbl = Tkinter.Label(frame, text="Table %d" % table_num)
+                    lbl.grid(row=0, column=0,
+                             columnspan=len(tables[table_num].rows[0]))
                     r = 1
                     for row in tables[table_num].rows:
                         c = 0
                         for line in row:
-                            l = Tkinter.Label(frame, text=line.text)
-                            l.grid(row=r, column=c)
+                            lbl = Tkinter.Label(frame, text=line.text)
+                            lbl.grid(row=r, column=c)
                             c += 1
                         r += 1
                     frame.grid(row=table_num, column=0)
                     table_num += 1
                 if not tables:
                     msg = "No tables found on page %d" % number
-                    l = Tkinter.Label(window, text=msg)
-                    l.grid(row=0, column=0)
+                    lbl = Tkinter.Label(window, text=msg)
+                    lbl.grid(row=0, column=0)
                     table_num = 1
                 b = Tkinter.Button(window, text="Back",
                                    command=lambda window=window, paper=paper:
@@ -1663,9 +1666,9 @@ class Manager:
             for c in window.winfo_children():
                 c.destroy()
             window.title("Select page")
-            l = Tkinter.Label(window, text="Page number(1 - %d):"
-                              % paper.num_pages)
-            l.grid(row=0, column=0)
+            lbl = Tkinter.Label(window, text="Page number(1 - %d):"
+                                % paper.num_pages)
+            lbl.grid(row=0, column=0)
             e = Tkinter.Entry(window, width=10)
             e.grid(row=0, column=1)
             e.focus_set()
@@ -1708,9 +1711,10 @@ class Manager:
                     else:
                         header_row = False
                         color = "black"
-                    for l in row:
-                        cnvs.create_rectangle((l.left, l.top + 10, l.right,
-                                               l.bottom + 10), outline=color)
+                    for line in row:
+                        cnvs.create_rectangle((line.left, line.top + 10,
+                                               line.right, line.bottom + 10),
+                                              outline=color)
 
                 b = Tkinter.Button(window, text="Back",
                                    command=lambda window=window, paper=paper:

--- a/Utils/Dataflow/030_PDFAnalyzer/manager.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/manager.py
@@ -1205,10 +1205,6 @@ class Manager:
         selection = Tkinter.StringVar()
         for key in d:
             if len(d[key]) > 10:
-                if len(d[key]) > 50:
-                    bt = d[key][:50] + "..."
-                else:
-                    bt = d[key]
                 if r == 1:
                     selection.set(d[key])
                 button = Tkinter.Radiobutton(window, text=d[key],

--- a/Utils/Dataflow/030_PDFAnalyzer/manager.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/manager.py
@@ -1248,7 +1248,7 @@ class Manager:
                     # This throws exception sometimes, something about
                     # ascii codec unable to decode.
                     w_in = w in possible_title
-                except:
+                except Exception as e:
                     w_in = False
                 if len(w) > 1 and w_in:
                     i += 1

--- a/Utils/Dataflow/030_PDFAnalyzer/pdfwork.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/pdfwork.py
@@ -45,9 +45,6 @@ def get_page_text(interpreter, page, tmp, rotation=0):
     interpreter.process_page(page)
     tmp.seek(0)
     text = remove_ligatures(tmp.read())
-#    newlines = []
-#    for l in lines:
-#        newlines.append(remove_ligatures(l))
     tmp.seek(0)
     tmp.truncate()
     return text

--- a/Utils/Dataflow/030_PDFAnalyzer/pdfwork.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/pdfwork.py
@@ -98,10 +98,10 @@ def mine_text(infname, page_numbers=False, outtype="text", rotated_pages=[],
                     single = 0
                     normal = 0
                     lines = text.split("\n")
-                    for l in lines:
-                        if not l.isspace():
-                            l = l.strip()
-                            if len(l) == 1:
+                    for line in lines:
+                        if not line.isspace():
+                            line = line.strip()
+                            if len(line) == 1:
                                 single += 1
                             normal += 1
                     coef = float(single) / normal

--- a/Utils/Dataflow/030_PDFAnalyzer/xmltable.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/xmltable.py
@@ -208,9 +208,6 @@ class Table:
         # are above each other. No additional spaces are added.
         rows = []
         for row in self.rows:
-            # print "ROW"
-            # for l in row:
-            #     print l.text, l.left, l.top, l.right, l.bottom
             new_row = []
             line = row[0]
             for i in range(1, len(row)):
@@ -271,9 +268,6 @@ class Table:
 #        print "ROWS"
         # Divide rows on short and normal.
         for row in self.rows:
-            #            print "ROW"
-            #            for l in row:
-            #                print l.text, l.left, l.top, l.right, l.bottom
             if len(row) == max_elements:
                 normal_rows.append(row)
             else:
@@ -283,7 +277,6 @@ class Table:
         # row.
         main_centers = []
         for l in main_row:
-            #            print "MAIN CENTER", (l.left + l.right)/2
             main_centers.append((l.left + l.right) / 2)
         # Calculate x boundaries of each column.
         boundaries = []
@@ -313,8 +306,6 @@ class Table:
                     # If line crosses the space entirely, attempt to
                     # break it on one of the spaces in it.
                     if l.left < cs[0] and l.right > cs[1]:
-                        # print "LINE OVER BOUNDARIES", l.text, l.left,\
-                        #     l.right, l.spaces_coords, cs
                         # We cannot break a line if there are no spaces.
                         # This means that line is, most likely, not needed.
                         if not l.spaces_coords:
@@ -438,29 +429,3 @@ def analyze_page(text):
     rows.sort(key=lambda row: row_centery(row))
 
     return rows
-# for row in rows:
-# if row[0].text.isdigit():
-# print "NUM ROW"
-# else:
-# print "OTHER ROW"
-# for l in row:
-# print l.text
-# if row.index(l) == 0:
-# print "ROW LEFT:", l.left
-# elif row.index(l) == len(row):
-# print "ROW RIGHT:", l.right
-
-#    symbols = {}
-#    lines = []
-# for l in tlines:
-#        lines.append(TextLine(l, symbols))
-#
-#    max_s = max(symbols.values())
-# for key in symbols:
-# if symbols[key] == max_s:
-#            max_key = key
-# break
-# print "KEY", max_key
-# for l in lines:
-# if max_key in l.symbols:
-# print l.text

--- a/Utils/Dataflow/030_PDFAnalyzer/xmltable.py
+++ b/Utils/Dataflow/030_PDFAnalyzer/xmltable.py
@@ -33,8 +33,8 @@ class TextLine:
             self.text = ""
             if text_symbols is not None:
                 self.symbols = {}
-                for l in lines:
-                    f = self.re_text_symbol_params.match(l)
+                for line in lines:
+                    f = self.re_text_symbol_params.match(line)
                     if f:
                         self.text += f.group(3)
                         font = f.group(1)
@@ -64,18 +64,18 @@ class TextLine:
             self.top = float(self.top)
             self.bottom = float(self.bottom)
 
-            for l in lines:
-                f = self.re_text_symbol.match(l)
+            for line in lines:
+                f = self.re_text_symbol.match(line)
                 if f:
                     self.text += f.group(1)
-                    coords = self.re_bbox.search(l)
+                    coords = self.re_bbox.search(line)
                     if coords:
                         [l0, t0, r0, b0] = coords.group(1).split(",")
                         if after_space:
                             self.spaces_coords[-1][1] = float(l0)
                             after_space = False
                     continue
-                f = self.re_text_space.match(l)
+                f = self.re_text_space.match(line)
                 if f:
                     self.text += " "
                     self.spaces_coords.append([float(r0), 0])
@@ -138,8 +138,8 @@ class TextLine:
 def row_centery(row):
     """ Calculate average y-center in a row. """
     c = 0
-    for l in row:
-        c += l.center[1]
+    for line in row:
+        c += line.center[1]
     c /= len(row)
     return c
 
@@ -159,9 +159,9 @@ class Table:
         rows = []
         t = []
         # Construct rows out of lines
-        for l in self.lines:
-            if l not in t:
-                row = self.construct_row(l, t)
+        for line in self.lines:
+            if line not in t:
+                row = self.construct_row(line, t)
                 rows.append(row)
                 t += row
         rows.sort(key=lambda row: row_centery(row))
@@ -172,12 +172,12 @@ class Table:
         self.rows = []
         for row in rows:
             date_row = False
-            for l in row:
-                if self.re_month.search(l.text.lower()):
+            for line in row:
+                if self.re_month.search(line.text.lower()):
                     date_row = True
                     break
             if not date_row:
-                row.sort(key=lambda l: l.center[0])
+                row.sort(key=lambda line: line.center[0])
                 self.rows.append(row)
 
         r = len(self.rows) - 1
@@ -238,15 +238,16 @@ class Table:
                     # print "MAXIMUM BREAKING ATTEMPTS REACHED"
                     break
 
-    def construct_row(self, line, used_lines):
+    def construct_row(self, first_line, used_lines):
         """ Construct a row which contains given line.
 
         Lines which were already used are not used again.
         """
-        row = [line]
-        for l in self.lines:
-            if l != line and l not in used_lines and line.same_row(l):
-                row.append(l)
+        row = [first_line]
+        for line in self.lines:
+            if line != first_line and line not in used_lines \
+                    and first_line.same_row(line):
+                row.append(line)
         return row
 
     def row_text(self, num=None, row=False):
@@ -257,8 +258,8 @@ class Table:
         if num is not None or num == 0:
             row = self.rows[num]
         text = ""
-        for l in row:
-            text += l.text + "!"
+        for line in row:
+            text += line.text + "!"
         return text
 
     def break_short_rows(self, max_elements):
@@ -276,8 +277,8 @@ class Table:
         # Calculate x coord for centers of each column in first normal
         # row.
         main_centers = []
-        for l in main_row:
-            main_centers.append((l.left + l.right) / 2)
+        for line in main_row:
+            main_centers.append((line.left + line.right) / 2)
         # Calculate x boundaries of each column.
         boundaries = []
         for i in range(0, max_elements):
@@ -301,36 +302,36 @@ class Table:
         for row in short_rows:
             new_row = []
 #            print "SHORT ROW", self.row_text(row = row)
-            for l in row:
+            for line in row:
                 for cs in column_spaces:
                     # If line crosses the space entirely, attempt to
                     # break it on one of the spaces in it.
-                    if l.left < cs[0] and l.right > cs[1]:
+                    if line.left < cs[0] and line.right > cs[1]:
                         # We cannot break a line if there are no spaces.
                         # This means that line is, most likely, not needed.
-                        if not l.spaces_coords:
+                        if not line.spaces_coords:
                             # print "LINE HAS NO SPACES TO BREAK ON, REMOVING"
-                            l = None
+                            line = None
                             break
                         else:
                             # Find the line space closest to column space.
                             cs2 = (cs[1] + cs[0]) / 2
-                            cls = min(l.spaces_coords,
+                            cls = min(line.spaces_coords,
                                       key=lambda space:
                                       abs((space[1] + space[0]) / 2 - cs2))
                             if abs((cls[1] + cls[0]) / 2 - cs2) > 5000:
                                 # TO DO: fix this.
                                 # print "LINE ONLY HAS SPACES TOO FAR\
                                 # FROM COLUMN BOUNDARIES, REMOVING"
-                                l = None
+                                line = None
                                 break
 #                            print "BREAKING ON SPACE", \
 #                                  closest_space  # min_x[0]
-                            [nl1, nl2] = l.split(cls)
+                            [nl1, nl2] = line.split(cls)
                             new_row.append(nl1)
-                            l = nl2
-                if l is not None:
-                    new_row.append(l)
+                            line = nl2
+                if line is not None:
+                    new_row.append(line)
             # Make sure that new row has enough members.
             if new_row:
                 #                print "NEW_ROW", self.row_text(row = new_row)
@@ -342,8 +343,8 @@ class Table:
                         break
                     i = 0
                     existing_column = False
-                    for l in new_row:
-                        if l.left <= c and l.right >= c:
+                    for line in new_row:
+                        if line.left <= c and line.right >= c:
                             existing_column = True
                             break
                     # If there is no line corresponding a center, add
@@ -355,7 +356,7 @@ class Table:
                                        new_row[0].bottom, "EMPTY", []])
                         new_row.append(nl)
                         num_lines += 1
-                new_row.sort(key=lambda l: l.center[0])
+                new_row.sort(key=lambda line: line.center[0])
                 self.rows.append(new_row)
         self.rows.sort(key=lambda row: row_centery(row))
 
@@ -368,8 +369,8 @@ def get_tables_from_text(text):
     tlines = re_textline.findall(text)
     lines = []
     table_headers = []
-    for l in tlines:
-        tl = TextLine(l)
+    for line in tlines:
+        tl = TextLine(line)
         if re_table_header.match(tl.text):
             table_headers.append(tl)
         else:
@@ -377,9 +378,9 @@ def get_tables_from_text(text):
 
     # Find the highest top coordinate possible and use it as a zero
     # point for new Y axis.
-    top = max(table_headers + lines, key=lambda l: l.top).top
-    for l in table_headers + lines:
-        l.swap_y(top)
+    top = max(table_headers + lines, key=lambda line: line.top).top
+    for line in table_headers + lines:
+        line.swap_y(top)
 
     table_headers.sort(key=lambda x: x.center[1])
 
@@ -388,11 +389,11 @@ def get_tables_from_text(text):
     for header in table_headers:
         table_lines = []
         remaining_lines = []
-        for l in lines:
-            if l.center[1] < header.center[1]:
-                table_lines.append(l)
+        for line in lines:
+            if line.center[1] < header.center[1]:
+                table_lines.append(line)
             else:
-                remaining_lines.append(l)
+                remaining_lines.append(line)
 
         table = Table(header.text, table_lines)
         if table.rows:
@@ -404,15 +405,15 @@ def get_tables_from_text(text):
 def analyze_page(text):
     tlines = re_textline.findall(text)
     lines = []
-    for l in tlines:
-        tl = TextLine(l)
+    for line in tlines:
+        tl = TextLine(line)
         lines.append(tl)
 
     # Find the highest top coordinate possible and use it as a zero
     # point for new Y axis.
-    top = max(lines, key=lambda l: l.top).top
-    for l in lines:
-        l.swap_y(top)
+    top = max(lines, key=lambda line: line.top).top
+    for line in lines:
+        line.swap_y(top)
 
     t = []
     rows = []
@@ -420,10 +421,10 @@ def analyze_page(text):
     for line in lines:
         if line not in t:
             row = [line]
-            for l in lines:
-                if l != line and l not in t and line.same_row(l):
-                    row.append(l)
-            row.sort(key=lambda l: l.center[0])
+            for nline in lines:
+                if nline != line and nline not in t and line.same_row(nline):
+                    row.append(nline)
+            row.sort(key=lambda nline: nline.center[0])
             rows.append(row)
             t += row
     rows.sort(key=lambda row: row_centery(row))

--- a/Utils/Dataflow/091_datasetsRucio/datasets_processing.py
+++ b/Utils/Dataflow/091_datasetsRucio/datasets_processing.py
@@ -125,7 +125,7 @@ def get_dataset_info(dataset):
         else:
             ds_dict['bytes'] = bytes
             ds_dict['deleted'] = False
-    except:
+    except RucioException:
         # if dataset wasn't find in Rucio, it means that it was deleted from
         # the Rucio catalog. In this case 'deleted' is set to TRUE and
         # the length of file is set to -1

--- a/Utils/Dataflow/skel/stage.py
+++ b/Utils/Dataflow/skel/stage.py
@@ -62,5 +62,6 @@ def main(args):
 
     exit(exit_code)
 
+
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
As `pep8` is obsolete, we may switch to the recomended `pycodestyle`.
However `pycodestyle` is a bit more strict about some things (see the Travis checks for this PR).
Particularly, it suggests to:
* E741: avoid ambiguous variable names (like 'l', 'O', 'I');
* E722: avoid "bare except".

The first, I think, need no additional explaination. It is just a question of "shell we pretend there`s no ambiguity" or fix it now.

For the second I would refer to the PEP-8 itself:

    A bare "except:" clause will catch SystemExit and KeyboardInterrupt exceptions,
    making it harder to interrupt a program with Control-C, and can disguise other problems.
    If you want to catch all exceptions that signal program errors, use "except Exception:"
    (bare except is equivalent to "except BaseException:").

    A good rule of thumb is to limit use of bare 'except' clauses to two cases:

    1. If the exception handler will be printing out or logging the traceback;
       at least the user will be aware that an error has occurred.
    2. If the code needs to do some cleanup work, but then lets the exception
       propagate upwards with raise. try...finally can be a better way to handle this case.

In those cases `pycodestyle` catches none of these two variants is not the case.

I can fix both codestyle issues here (or authors could do it themselves, as I can ruin something by accident, especially in case of variable naming).
Or I can add these two codes to ignore list of Travis checks, if there are any reasons we do intend to ignore it.

---

@Evildoor, mostly it affects the Stage 030, so I would like to hear from you in the comments.