### PR TITLE
SQL: LEFT JOIN error fixed

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/query/prodsys2ES.sql
+++ b/Utils/Dataflow/009_oracleConnector/query/prodsys2ES.sql
@@ -279,9 +279,9 @@ with tasks as (
     sum(jd.neventsused) AS processed_events
   FROM tasks_t_task t
     LEFT JOIN ATLAS_PANDA.jedi_datasets jd
-      ON jd.jeditaskid = t.taskid
-  WHERE jd.type IN ('input')
-        AND jd.masterid IS NULL
+      ON t.taskid = jd.jeditaskid
+      AND jd.type IN ('input')
+      AND jd.masterid IS NULL
   GROUP by
     t.campaign,
     t.subcampaign,


### PR DESCRIPTION
The issue is that LEFT JOIN doesn't return all records
from the left table.

The solution is to change WHERE clause to AND
so that the condition is part of the join condition, not a filter applied after the join.
Now all rows in the left table will be present in the result.