### PR TITLE
DF/data4es: add `data4es-status` script.

### DIFF
--- a/Utils/Dataflow/run/data4es-status
+++ b/Utils/Dataflow/run/data4es-status
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+base_dir=$( cd "$(dirname "$(readlink -f "$0")")"; pwd)
+pidfile=$base_dir/$(basename "$0" | cut -d- -f1).pid
+
+[ -r "$pidfile" ] \
+  || { echo "[FAIL] Can't read $pidfile" >&2 ; exit 1; }
+
+pid=`grep 'source' $pidfile`
+[ $? -gt 0 ] \
+  && { echo "[FAIL] Can't find source connector PID in $pidfile" >&2;
+       exit 1; }
+
+pid=`echo "$pid" | cut -d' ' -f 1`
+for p in $pid; do
+  ps axo pid | grep "^\s*${pid}$" >/dev/null 2>&1
+
+  [ $? -eq 0 ] \
+    && { echo "[RUNNING] Source connector is running." >&2
+         exit 0; }
+done
+
+echo "[NOT RUNNING] Source connector is not running." >&2
+exit 2


### PR DESCRIPTION
It checks current state of the `data4es` dataflow: if it is running
  or not.

---

Required for full automatization of `data4es` dataflow in CERN.