### PR TITLE
pyDKB: EOM/EOP markers

### DIFF
--- a/Utils/Dataflow/pyDKB/common/__init__.py
+++ b/Utils/Dataflow/pyDKB/common/__init__.py
@@ -5,5 +5,5 @@ Common modules.
 from exceptions import *
 import hdfs
 import json_utils as json
-import custom_readline
+from custom_readline import custom_readline
 from Type import Type

--- a/Utils/Dataflow/pyDKB/common/__init__.py
+++ b/Utils/Dataflow/pyDKB/common/__init__.py
@@ -5,4 +5,5 @@ Common modules.
 from exceptions import *
 import hdfs
 import json_utils as json
+import custom_readline
 from Type import Type

--- a/Utils/Dataflow/pyDKB/common/custom_readline.py
+++ b/Utils/Dataflow/pyDKB/common/custom_readline.py
@@ -1,0 +1,33 @@
+import select
+import os
+import fcntl
+
+
+def custom_readline(f, newline):
+    """Custom readline() function.
+
+    Custom_readline() separates content from a text file 'f'
+    by delimiter 'newline' to distinct messages.
+    The last line can be incomplete, if the input data flow is interrupted
+    in the middle of data writing.
+
+    Keyword arguments:
+    f -- file/stream to read
+    newline -- custom delimiter
+    """
+    poller = select.poll()
+    poller.register(f, select.POLLIN)
+    flags = fcntl.fcntl(f.fileno(), fcntl.F_GETFL)
+    fcntl.fcntl(f.fileno(), fcntl.F_SETFL, flags | os.O_NONBLOCK)
+    buf = ""
+    while True:
+        if poller.poll(500):
+            chunk = f.read()
+            if not chunk:
+                yield buf
+                break
+            buf += chunk
+        while newline in buf:
+            pos = buf.index(newline)
+            yield buf[:pos]
+            buf = buf[pos + len(newline):]

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
@@ -309,8 +309,12 @@ class AbstractProcessorStage(AbstractStage):
             iterator = iter(fd.readline, "")
         else:
             iterator = custom_readline(fd, self.ARGS.eom)
-        for line in iterator:
+        try:
+            for line in iterator:
                 yield self.parseMessage(line)
+        except KeyboardInterrupt:
+            sys.stderr.write("(INFO) Interrupted by user.\n")
+            sys.exit()
 
     def file_input(self, fd):
         """ Generator for input messages.

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
@@ -49,6 +49,7 @@ from . import messageType
 from . import Message
 from pyDKB.dataflow import DataflowException
 from pyDKB.common import hdfs
+from pyDKB.common.custom_readline import custom_readline
 
 
 class AbstractProcessorStage(AbstractStage):
@@ -309,8 +310,8 @@ class AbstractProcessorStage(AbstractStage):
             for line in iterator:
                 yield self.parseMessage(line)
         else:
-            raise NotImplementedError("Stream input is not implemented for"
-                                      " custom EOMessage marker.")
+            for line in custom_readline(fd, self.ARGS.eom):
+                yield self.parseMessage(line)
 
     def file_input(self, fd):
         """ Generator for input messages.

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
@@ -49,7 +49,7 @@ from . import messageType
 from . import Message
 from pyDKB.dataflow import DataflowException
 from pyDKB.common import hdfs
-from pyDKB.common.custom_readline import custom_readline
+from pyDKB.common import custom_readline
 
 
 class AbstractProcessorStage(AbstractStage):

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
@@ -78,9 +78,6 @@ class AbstractProcessorStage(AbstractStage):
     __input_message_class = None
     __output_message_class = None
 
-    __stream_EOMessage = '\n'
-    __stream_EOProcess = '\0'
-
     def __init__(self, description="DKB Dataflow data processing stage."):
         """ Initialize the stage
 
@@ -94,8 +91,6 @@ class AbstractProcessorStage(AbstractStage):
         self.__input = []
         self.__output_buffer = []
         self.__stoppable = []
-        self.__EOMessage = '\n'
-        self.__EOProcess = '\n'
         super(AbstractProcessorStage, self).__init__(description)
 
     def _set_input_message_class(self, Type=None):
@@ -227,8 +222,6 @@ class AbstractProcessorStage(AbstractStage):
         elif self.ARGS.dest == 's':
             ustdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
             self.__output = ustdout
-            self.__EOMessage = self.__stream_EOMessage
-            self.__EOProcess = self.__stream_EOProcess
 
         self.__stoppable_append(self.__output, types.GeneratorType)
 
@@ -311,7 +304,7 @@ class AbstractProcessorStage(AbstractStage):
         Split stream into messages;
         Yield Message object.
         """
-        if self.__EOMessage == '\n':
+        if self.ARGS.eom == '\n':
             iterator = iter(fd.readline, "")
             for line in iterator:
                 yield self.parseMessage(line)
@@ -344,7 +337,7 @@ class AbstractProcessorStage(AbstractStage):
     def forward(self):
         """ Send EOPMessage in the streaming output mode. """
         if self.ARGS.dest == 's':
-            self.__output.write(self.__EOProcess)
+            self.__output.write(self.ARGS.eop)
 
     def flush_buffer(self):
         """ Flush message buffer to the output. """
@@ -359,7 +352,7 @@ class AbstractProcessorStage(AbstractStage):
             fd = self.__output
         for msg in self.__output_buffer:
             fd.write(msg.encode())
-            fd.write(self.__EOMessage)
+            fd.write(self.ARGS.eom)
 
     def file_flush(self):
         """ Flush message buffer into a file.

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractProcessorStage.py
@@ -307,10 +307,9 @@ class AbstractProcessorStage(AbstractStage):
         """
         if self.ARGS.eom == '\n':
             iterator = iter(fd.readline, "")
-            for line in iterator:
-                yield self.parseMessage(line)
         else:
-            for line in custom_readline(fd, self.ARGS.eom):
+            iterator = custom_readline(fd, self.ARGS.eom)
+        for line in iterator:
                 yield self.parseMessage(line)
 
     def file_input(self, fd):

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -3,6 +3,7 @@ Definition of an abstract class for Dataflow Stages.
 """
 
 import sys
+import textwrap
 
 try:
     import argparse
@@ -29,7 +30,29 @@ class AbstractStage(object):
         * ...
         """
         self.ARGS = None
-        self.__parser = argparse.ArgumentParser(description=description)
+        self.__parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=description,
+            epilog=textwrap.dedent(
+                '''\
+                NOTES
+
+                Processing mode
+                  is defined as a combination of data source and
+                  destination type (local/HDFS file(s) or standard stream)
+                  and pre-defined EOP and EOM markers:
+
+                  mode | source | dest | eom | eop
+                  -----+--------+------+-----+-----
+                    s  |    s   |   s  |  \\n |  \\0
+                  -----+--------+------+-----+-----
+                    f  |   f/h  |  f/h |  \\n |
+                  -----+--------+------+-----+-----
+                    m  |   s/h  |   s  |  \\n |
+                  -----+--------+------+-----+-----
+                    h  |    h   |  h/f |  \\n |
+                  -----+--------+------+-----+-----''')
+        )
         self.defaultArguments()
 
     def defaultArguments(self):

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -68,6 +68,8 @@ class AbstractStage(object):
 
         if self.ARGS.eom is None:
             self.ARGS.eom = '\n'
+        elif self.ARGS.eom == '':
+            raise ValueError("(ERROR) Empty EOM marker specified.")
         else:
             try:
                 self.ARGS.eom = self.ARGS.eom.decode('string_escape')

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -42,6 +42,18 @@ class AbstractStage(object):
                           choices=['f', 's', 'm'],
                           dest='mode'
                           )
+        self.add_argument('-e', '--end-of-message', action='store', type=str,
+                          help=u'Custom end of message marker.',
+                          nargs='?',
+                          default=None,
+                          dest='eom'
+                          )
+        self.add_argument('-E', '--end-of-process', action='store', type=str,
+                          help=u'Custom end of process marker.',
+                          nargs='?',
+                          default=None,
+                          dest='eop'
+                          )
 
     def add_argument(self, *args, **kwargs):
         """ Add specific (not common) arguments. """
@@ -53,6 +65,29 @@ class AbstractStage(object):
         if not self.ARGS.mode:
             raise ValueError(
                 "Parameter -m|--mode must be used with value: -m MODE.")
+
+        if self.ARGS.eom is None:
+            self.ARGS.eom = '\n'
+        else:
+            try:
+                self.ARGS.eom = self.ARGS.eom.decode('string_escape')
+            except (ValueError), err:
+                sys.stderr.write("(ERROR) Failed to read arguments.\n"
+                                 "(ERROR) Case: %s\n" % (err))
+                sys.exit(1)
+
+        if self.ARGS.eop is None:
+            if self.ARGS.mode == 's':
+                self.ARGS.eop = '\0'
+            else:
+                self.ARGS.eop = ''
+        else:
+            try:
+                self.ARGS.eop = self.ARGS.eop.decode('string_escape')
+            except (ValueError), err:
+                sys.stderr.write("(ERROR) Failed to read arguments.\n"
+                                 "(ERROR) Case: %s\n" % (err))
+                sys.exit(1)
 
     def print_usage(self, fd=sys.stderr):
         """ Print usage message. """


### PR DESCRIPTION
- [x] Implement EOM/EOP shortcuts.
- [x] Implement custom markers from the console.
- [x] Set up stdin in a non-blocking mode.
- [x] Implement custom readline function.
- [x] Mention the shortcut table in the --mode parameter description or epilog.
- [x] Add KeyboardInterrupt handler.