### PR TITLE
[stack] pyDKB development (pt.5): improve output_error() method of AbstractProcessor.

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -227,11 +227,10 @@ class AbstractStage(object):
                 n_lines = len(trace)
                 # List of log levels with number of lines
                 # to be output with this level
-                levels = [(logLevel.TRACE, -1), (logLevel.DEBUG, 8),
-                          (logLevel.ERROR, 3)]
+                levels = [(logLevel.DEBUG, -1), (logLevel.ERROR, 1)]
                 for i in xrange(n_lines):
                     for lvl, N in levels:
-                        if not N - 1 < i < n_lines - N or N < 0:
+                        if i >= n_lines - N or N < 0:
                             cur_lvl = lvl
                     msg = trace[i]
                     self.log(msg, cur_lvl)


### PR DESCRIPTION
It used to output with `logLevel.X` first and last N lines:
* ERROR: 3 lines
* DEBUG: 8 lines (but the 3 with ERROR level)
* TRACE: all the others

Now it outputs with `logLevel.X` only the last N lines:
* ERROR: 1 line
* DEBUG: all the others

I believe that the last line gives the most important information to
understand the content of the error; whole traceback (including first
lines) is required only for debug.
TRACE level is more to understand how things are going during the
program execution to locate unexpected behaviour, not to "get more
detais about the error".