### PR TITLE
DF: data4es config lookup

### DIFF
--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -5,16 +5,36 @@ log() {
 
 usage() {
   echo "USAGE:
-$(basename "$0") [FILE...]
+$(basename "$0") [-c CONFIG] [FILE...]
 
 PARAMETERS:
-  FILE -- file in NDJSON format for loading to Elasticsearch via bulk interface
+  CONFIG -- configuration file
+  FILE   -- file in NDJSON format for loading to Elasticsearch via bulk interface
 "
 }
 
 base_dir=$( cd "$( dirname "$( readlink -f "$0" )" )" && pwd )
 
 ES_CONFIG="${base_dir}/../../Elasticsearch/config/es"
+
+while [ -n "$1" ]; do
+  case "$1" in
+    --config|-c)
+      [ -n "$2" ] && ES_CONFIG="$2" || { usage >&2 && exit 1; }
+      shift;;
+    --)
+      shift
+      break;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1;;
+    *)
+      break;;
+  esac
+  shift
+done
+
 log "Loading defaults and config $ES_CONFIG if any"
 ES_HOST='127.0.0.1'
 ES_PORT='9200'

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -7,6 +7,11 @@ DEBUG=
 base_dir=$( cd "$(dirname "$(readlink -f "$0")")"; pwd)
 pidfile=$base_dir/$(basename "$0" | cut -d- -f1).pid
 
+# Directories with configuration files
+[ -n "$DATA4ES_CONFIG_PATH" ] && \
+    CONFIG_PATH="$DATA4ES_CONFIG_PATH" || \
+    CONFIG_PATH="${base_dir}/../config:${base_dir}/../../Elasticsearch/config"
+
 # Create aux directories
 # ---
 pipe_dir=$base_dir/.pipe
@@ -15,11 +20,26 @@ mkdir -p $pipe_dir
 buffer_dir=$base_dir/.buffer
 mkdir -p $buffer_dir
 
+
 # Define commands to be used as dataflow nodes
 # ---
+
+# Find configuration file in $CONFIG_PATH
+get_config() {
+  [ -z "$1" ] && echo "get_config(): no argumets passed." && return 1
+  dirs=$CONFIG_PATH
+  while [ -n "$dirs" ]; do
+    dir=${dirs%%:*}
+    [ "$dirs" = "$dir" ] && \
+        dirs='' || \
+        dirs="${dirs#*:}"
+    [ -f "${dir}/${1}" ] && readlink -f "${dir}/${1}" && return 0
+  done
+}
+
 # Oracle Connector
 cmd_09="${base_dir}/../009_oracleConnector/Oracle2JSON.py"
-cfg_09="${base_dir}/../config/009.cfg"
+cfg_09=`get_config "009.cfg"`
 cmd_OC="$cmd_09 --config $cfg_09 --mode SQUASH"
 
 # Stage 16
@@ -38,7 +58,7 @@ cmd_91="${base_dir}/../091_datasetsRucio/datasets_processing.py -m s"
 cmd_93="${base_dir}/../093_datasetsFormat/datasets_format.py -m s"
 
 # Stage 95
-auth_cfg=${base_dir}/../config/095.cfg
+auth_cfg=`get_config "095.cfg"`
 source $auth_cfg
 [ -r "$AUTH_KEY" -a -r "$AUTH_CRT" ] \
   || { echo "Stage 095: wrong authentication parameters (failed to read certificate files: $AUTH_KEY and $AUTH_CRT)" >&2;

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -49,7 +49,8 @@ cmd_16="${base_dir}/../016_task2es/task2es.py -m s"
 cmd_19="${base_dir}/../019_esFormat/run.sh"
 
 # Stage 69
-cmd_69="${base_dir}/../069_upload2es/load_data.sh"
+cfg_69=`get_config "es"`
+cmd_69="${base_dir}/../069_upload2es/load_data.sh --config $cfg_69"
 
 # Stage 91
 cmd_91="${base_dir}/../091_datasetsRucio/datasets_processing.py -m s"


### PR DESCRIPTION
Sometimes we need to run two or more `data4es` processes with different
configurations (say, regular updates every hour, reverse update for data
repair, weekly update to get updated data from original sources, where
timestamp was not updated properly). To make it possible, we need to at
least be able to set "where to read configuration from" without changing
code.