### PR TITLE
data4es: fix config file usage (stage 19)

### DIFF
--- a/Utils/Dataflow/019_esFormat/run.sh
+++ b/Utils/Dataflow/019_esFormat/run.sh
@@ -2,7 +2,34 @@
 
 base_dir=$(cd "$(dirname "$(readlink -f "$0")")"; pwd)
 
+usage() {
+  echo "USAGE:
+$(basename "$0") [-c CONFIG]
+  
+PARAMETERS:
+  CONFIG -- configuration file
+"
+}
+
 ES_CONFIG=$base_dir/../../Elasticsearch/config/es
+
+while [ -n "$1" ]; do
+  case "$1" in
+    --config|-c)
+      [ -n "$2" ] && ES_CONFIG="$2" || { usage >&2 && exit 1; }
+      shift;;
+    --)
+      shift
+      break;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1;;
+    *)
+      break;;
+  esac
+  shift
+done
 
 [ -r "$ES_CONFIG" ] \
   || { echo "Can't access configuration file: $ES_CONFIG" >&2 \

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -62,7 +62,8 @@ cmd_OC="$cmd_09 --config $cfg_09 --mode SQUASH"
 cmd_16="${base_dir}/../016_task2es/task2es.py -m s"
 
 # Stage 19
-cmd_19="${base_dir}/../019_esFormat/run.sh"
+cfg_19=`get_config "es"`
+cmd_19="${base_dir}/../019_esFormat/run.sh --config $cfg_19"
 
 # Stage 69
 cfg_69=`get_config "es"`


### PR DESCRIPTION
Stage 19, used in `data4es` process, never took config file firom command line and thus for any `data4es` process all ES settings were the same.