### PR TITLE
pyDKB/*/stream: bug fix (StreamException not defined).

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/communication/stream/Stream.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/stream/Stream.py
@@ -7,6 +7,7 @@ import sys
 from . import messageType
 from . import logLevel
 from . import Message
+from exceptions import StreamException
 
 
 class Stream(object):

--- a/Utils/Dataflow/pyDKB/dataflow/communication/stream/__init__.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/stream/__init__.py
@@ -13,13 +13,9 @@ from Stream import Stream
 from InputStream import InputStream
 from OutputStream import OutputStream
 
-__all__ = ['StreamBuilder', 'StreamException', 'Stream', 'InputStream',
-           'OutputStream']
+from exceptions import StreamException
 
-
-class StreamException(DataflowException):
-    """ Exception for Stream operations. """
-    pass
+__all__ = ['StreamBuilder', 'Stream', 'InputStream', 'OutputStream']
 
 
 class StreamBuilder(object):

--- a/Utils/Dataflow/pyDKB/dataflow/communication/stream/exceptions.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/stream/exceptions.py
@@ -1,0 +1,10 @@
+"""
+pyDKB.dataflow.communication.stream.exceptions
+"""
+
+from . import DataflowException
+
+
+class StreamException(DataflowException):
+    """ Exception for Stream operations. """
+    pass


### PR DESCRIPTION
Derfinition for StreamException is moved to a separate file, as it must
be imported in `stream` submodules, but was defined after the submodules
are imported in `__init__`.