### PR TITLE
pyDKB/*/consumer: make FileConsumer to check input file extension.

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/communication/consumer/Consumer.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/consumer/Consumer.py
@@ -58,7 +58,6 @@ class Consumer(object):
         """ (Re)initialize consumer with stage config arguments. """
         if config:
             self.config = config
-        self.init_stream()
 
     def init_stream(self):
         """ Init input stream. """


### PR DESCRIPTION
When only directory with input files is specified, it is better to work
only with files with proper extension (detected by input message type).
It allows to put output files to the same directory, or even work in the
same directory with the executable.

---
~Waits for: #149~ *(merged)*