### PR TITLE
[WIP] pyDKB: stage fix

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/communication/consumer/Consumer.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/consumer/Consumer.py
@@ -70,6 +70,18 @@ class Consumer(object):
                 .setType(self.message_type) \
                 .build()
 
+    def stream_is_empty(self):
+        """ Check if current stream is empty.
+
+        Return value:
+            True  (empty)
+            False (not empty)
+            None  (_stream is not defined or not initialized)
+        """
+        if not self._stream:
+            return None
+        return self._stream.is_empty()
+
     def get_stream(self):
         """ Get input stream linked to the current source.
 
@@ -77,7 +89,9 @@ class Consumer(object):
             InputStream
             None (no sources left to read from)
         """
-        if self.reset_stream():
+        if not self.stream_is_empty():
+            result = self._stream
+        elif self.reset_stream():
             result = self._stream
         else:
             result = None

--- a/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
@@ -48,6 +48,8 @@ class FileConsumer(Consumer.Consumer):
         if not f:
             return None
         fd = f['fd']
+        if not fd or getattr(fd, 'closed', True):
+            return None
         if not f.get('size'):
             stat = os.fstat(fd.fileno())
             f['size'] = stat.st_size

--- a/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
@@ -36,18 +36,6 @@ class FileConsumer(Consumer.Consumer):
 
         super(FileConsumer, self).reconfigure(config)
 
-    def source_is_empty(self):
-        """ Check if current source is empty.
-
-        Return value:
-            True  (empty)
-            False (not empty or stream for given source is not defined)
-            None  (no source)
-        """
-        if not self.current_file:
-            return None
-        return bool(self.stream_is_empty())
-
     def get_source_info(self):
         """ Return current source info. """
         return self.current_file
@@ -58,15 +46,20 @@ class FileConsumer(Consumer.Consumer):
             self.input_files = self._input_files()
 
     def get_source(self):
-        """ Get nearest non-empty source (current or next). """
-        if self.source_is_empty() is not False:
+        """ Return current source or None if no sources left.
+
+        Return values:
+            fd    -- open file descriptor for current data source
+            None  -- current source is not defined
+        """
+        if not self.current_file:
             result = self.next_source()
         else:
             result = self.current_file['fd']
         return result
 
     def next_source(self):
-        """ Reset $current_file to the next non-empty file.
+        """ Reset $current_file to the next file.
 
         Return value:
             File descriptor of the new $current_file
@@ -74,7 +67,7 @@ class FileConsumer(Consumer.Consumer):
         """
         try:
             self.current_file = self.input_files.next()
-            result = self.get_source()
+            result = self.current_file['fd']
         except StopIteration:
             self.current_file = None
             result = None

--- a/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
@@ -41,19 +41,12 @@ class FileConsumer(Consumer.Consumer):
 
         Return value:
             True  (empty)
-            False (not empty)
+            False (not empty or stream for given source is not defined)
             None  (no source)
         """
-        f = self.current_file
-        if not f:
+        if not self.current_file:
             return None
-        fd = f['fd']
-        if not fd or getattr(fd, 'closed', True):
-            return None
-        if not f.get('size'):
-            stat = os.fstat(fd.fileno())
-            f['size'] = stat.st_size
-        return fd.tell() == f['size']
+        return bool(self.stream_is_empty())
 
     def get_source_info(self):
         """ Return current source info. """

--- a/Utils/Dataflow/pyDKB/dataflow/communication/stream/InputStream.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/stream/InputStream.py
@@ -29,13 +29,17 @@ class InputStream(Stream):
         else:
             self.__iterator = custom_readline(fd, self.EOM)
 
-    def reset(self, fd, close=True):
+    def reset(self, fd, close=True, force=False):
         """ Reset current stream with new file descriptor.
 
         Overrides parent method to reset __iterator property.
         """
-        super(InputStream, self).reset(fd, close)
-        self._reset_iterator()
+        old_fd = super(InputStream, self).reset(fd, close)
+        # We do not want to reset iterator if `reset()` was called
+        # with the same `fd` as before.
+        if force or (old_fd and fd != old_fd):
+            self._reset_iterator()
+        return old_fd
 
     def parse_message(self, message):
         """ Verify and parse input message.

--- a/Utils/Dataflow/pyDKB/dataflow/communication/stream/Stream.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/stream/Stream.py
@@ -60,13 +60,16 @@ class Stream(object):
 
         :param fd: open file descriptor
                    TODO: IOBase objects
+        :return: previous file descriptor (or None)
         """
         if not isinstance(fd, (file, None.__class__)):
             raise TypeError("Stream.reset() expects first parameter of type"
                             " 'file' (got '%s')" % fd.__class__.__name__)
-        if close and self._fd != fd:
+        old_fd = self._fd
+        if close and old_fd != fd:
             self.close()
         self._fd = fd
+        return old_fd
 
     def get_fd(self):
         """ Return open file descriptor or raise exception. """

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -44,7 +44,7 @@ class AbstractStage(object):
         self.__config = ConfigParser.SafeConfigParser()
         self.ARGS = None
         self.__parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
+            formatter_class=argparse.RawTextHelpFormatter,
             description=description,
             epilog=textwrap.dedent(
                 '''\
@@ -120,6 +120,12 @@ class AbstractStage(object):
 
     def add_argument(self, *args, **kwargs):
         """ Add specific (not common) arguments. """
+        wrapper = textwrap.TextWrapper(width=55, replace_whitespace=False)
+        msg = textwrap.dedent(kwargs.get('help',''))
+        msg_lines = msg.split('\n')
+        wrapped_lines = [ wrapper.fill(line) for line in msg_lines ]
+        msg = '\n'.join(wrapped_lines)
+        kwargs['help'] = msg
         self.__parser.add_argument(*args, **kwargs)
 
     def parse_args(self, args):

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -90,7 +90,7 @@ class AbstractStage(object):
 
     def defaultArguments(self):
         """ Config argument parser with parameters common for all stages. """
-        self.add_argument('-m', '--mode', action='store', type=str, nargs='?',
+        self.add_argument('-m', '--mode', action='store', type=str,
                           help=u'processing mode: (f)ile, (s)tream'
                                 ' or (m)ap-reduce',
                           default='f',
@@ -99,7 +99,7 @@ class AbstractStage(object):
                           dest='mode'
                           )
         self.add_argument('-c', '--config', action='store',
-                          type=argparse.FileType('r'), nargs='?',
+                          type=argparse.FileType('r'),
                           help=u'stage configuration file',
                           default=None,
                           metavar='CONFIG',
@@ -114,7 +114,6 @@ class AbstractStage(object):
         self.add_argument('-E', '--end-of-process', action='store', type=str,
                           help=u'custom end of process marker.\n'
                                 'DEFAULT: \'\'',
-                          nargs='?',
                           default=None,
                           dest='eop'
                           )
@@ -141,9 +140,6 @@ class AbstractStage(object):
             3 -- failed to read config file
         """
         self.ARGS = self.__parser.parse_args(args)
-        if not self.ARGS.mode:
-            self.args_error("Parameter -m|--mode must be used with value:"
-                            " -m MODE.")
 
         if self.ARGS.eom is None:
             self.ARGS.eom = '\n'

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -92,7 +92,7 @@ class AbstractStage(object):
         """ Config argument parser with parameters common for all stages. """
         self.add_argument('-m', '--mode', action='store', type=str, nargs='?',
                           help=u'processing mode: (f)ile, (s)tream'
-                                ' or (m)ap-reduce (default: %(default)s)',
+                                ' or (m)ap-reduce',
                           default='f',
                           metavar='MODE',
                           choices=['f', 's', 'm'],
@@ -106,13 +106,14 @@ class AbstractStage(object):
                           dest='config'
                           )
         self.add_argument('-e', '--end-of-message', action='store', type=str,
-                          help=u'custom end of message marker',
-                          nargs='?',
+                          help=u'custom end of message marker.\n'
+                                'DEFAULT: \'\\n\'',
                           default=None,
                           dest='eom'
                           )
         self.add_argument('-E', '--end-of-process', action='store', type=str,
-                          help=u'custom end of process marker',
+                          help=u'custom end of process marker.\n'
+                                'DEFAULT: \'\'',
                           nargs='?',
                           default=None,
                           dest='eop'
@@ -121,9 +122,11 @@ class AbstractStage(object):
     def add_argument(self, *args, **kwargs):
         """ Add specific (not common) arguments. """
         wrapper = textwrap.TextWrapper(width=55, replace_whitespace=False)
-        msg = textwrap.dedent(kwargs.get('help',''))
+        msg = textwrap.dedent(kwargs.get('help', ''))
+        if kwargs.get('default', None) is not None:
+            msg += '\nDEFAULT: \'%(default)s\''
         msg_lines = msg.split('\n')
-        wrapped_lines = [ wrapper.fill(line) for line in msg_lines ]
+        wrapped_lines = [wrapper.fill(line) for line in msg_lines]
         msg = '\n'.join(wrapped_lines)
         kwargs['help'] = msg
         self.__parser.add_argument(*args, **kwargs)

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -91,8 +91,8 @@ class AbstractStage(object):
     def defaultArguments(self):
         """ Config argument parser with parameters common for all stages. """
         self.add_argument('-m', '--mode', action='store', type=str, nargs='?',
-                          help=u'Processing mode: (f)ile, (s)tream'
-                                ' or (m)ap-reduce (default: %(default)s).',
+                          help=u'processing mode: (f)ile, (s)tream'
+                                ' or (m)ap-reduce (default: %(default)s)',
                           default='f',
                           metavar='MODE',
                           choices=['f', 's', 'm'],
@@ -100,19 +100,19 @@ class AbstractStage(object):
                           )
         self.add_argument('-c', '--config', action='store',
                           type=argparse.FileType('r'), nargs='?',
-                          help=u'Stage configuration file.',
+                          help=u'stage configuration file',
                           default=None,
                           metavar='CONFIG',
                           dest='config'
                           )
         self.add_argument('-e', '--end-of-message', action='store', type=str,
-                          help=u'Custom end of message marker.',
+                          help=u'custom end of message marker',
                           nargs='?',
                           default=None,
                           dest='eom'
                           )
         self.add_argument('-E', '--end-of-process', action='store', type=str,
-                          help=u'Custom end of process marker.',
+                          help=u'custom end of process marker',
                           nargs='?',
                           default=None,
                           dest='eop'

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -129,6 +129,7 @@ class AbstractStage(object):
         msg_lines = msg.split('\n')
         wrapped_lines = [wrapper.fill(line) for line in msg_lines]
         msg = '\n'.join(wrapped_lines)
+        msg += '\n '
         kwargs['help'] = msg
         self.__parser.add_argument(*args, **kwargs)
 

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -123,7 +123,8 @@ class AbstractStage(object):
         """ Add specific (not common) arguments. """
         wrapper = textwrap.TextWrapper(width=55, replace_whitespace=False)
         msg = textwrap.dedent(kwargs.get('help', ''))
-        if kwargs.get('default', None) is not None:
+        if kwargs.get('default', None) is not None \
+                and not kwargs.get('action', '').startswith('store_'):
             msg += '\nDEFAULT: \'%(default)s\''
         msg_lines = msg.split('\n')
         wrapped_lines = [wrapper.fill(line) for line in msg_lines]

--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -45,26 +45,7 @@ class AbstractStage(object):
         self.ARGS = None
         self.__parser = argparse.ArgumentParser(
             formatter_class=argparse.RawTextHelpFormatter,
-            description=description,
-            epilog=textwrap.dedent(
-                '''\
-                NOTES
-
-                Processing mode
-                  is defined as a combination of data source and
-                  destination type (local/HDFS file(s) or standard stream)
-                  and pre-defined EOP and EOM markers:
-
-                  mode | source | dest | eom | eop
-                  -----+--------+------+-----+-----
-                    s  |    s   |   s  |  \\n |  \\0
-                  -----+--------+------+-----+-----
-                    f  |   f/h  |  f/h |  \\n |
-                  -----+--------+------+-----+-----
-                    m  |   s/h  |   s  |  \\n |
-                  -----+--------+------+-----+-----
-                    h  |    h   |  h/f |  \\n |
-                  -----+--------+------+-----+-----''')
+            description=description
         )
         self.defaultArguments()
 
@@ -92,7 +73,26 @@ class AbstractStage(object):
         """ Config argument parser with parameters common for all stages. """
         self.add_argument('-m', '--mode', action='store', type=str,
                           help=u'processing mode: (f)ile, (s)tream'
-                                ' or (m)ap-reduce',
+                                ' or (m)ap-reduce.\n'
+                                'Processing mode is defined as a combination '
+                                'of four parameters: '
+                                '"-s SRC -d DEST -e EOM -E EOP", '
+                                'where:\n'
+                                ' \n'
+                                ' mode || -s | -d | -e | -E\n'
+                                '===========================\n'
+                                '  s   ||  s |  s | \\n | \\0\n'
+                                '---------------------------\n'
+                                '  f   ||  f |  f | \\n | \'\'\n'
+                                '---------------------------\n'
+                                '  m   ||  s |  s | \\n | \'\'\n'
+                                ' \n'
+                                'Any of these parameters can be rewritten by '
+                                'its explicit specification.\n'
+                                'NOTE: for (m)ap-reduce mode, if --source is '
+                                'set to (h)dfs (via "-s" or "--hdfs"), names '
+                                'of files to be processed will be taken from '
+                                'STDIN.',
                           default='f',
                           metavar='MODE',
                           choices=['f', 's', 'm'],

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -122,7 +122,7 @@ class ProcessorStage(AbstractStage):
                           nargs='?',
                           help=u'Where to get data from: '
                                 'local (f)iles, (s)tdin, '
-                                '(h)dfs (same as --hdfs).',
+                                '(h)dfs.',
                           default='f',
                           const='f',
                           choices=['f', 's', 'h'],
@@ -142,7 +142,7 @@ class ProcessorStage(AbstractStage):
         self.add_argument('-d', '--dest', action='store', type=str, nargs='?',
                           help=u'Where to send results: '
                                 'local (f)iles, (s)tdout, '
-                                '(h)dfs (same as --hdfs).',
+                                '(h)dfs.',
                           default='f',
                           const='f',
                           choices=['f', 's', 'h'],
@@ -157,11 +157,11 @@ class ProcessorStage(AbstractStage):
                           dest='output_dir'
                           )
         self.add_argument('--hdfs', action='store_true',
-                          help=u'Source files are stored in HDFS; '
-                          'if no input FILE specified, filenames will '
-                          'come to stdin. '
-                          'This option is equivalent to '
-                          '"--source h --dest h"',
+                          help=u'Equivalent to '
+                          '"--source h --dest h"; explicit specification of '
+                          '"--source" and "--dest", as well as the default '
+                          'values for current processing mode ("--mode") will '
+                          'be ignored.',
                           default=False,
                           dest='hdfs'
                           )

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -120,9 +120,10 @@ class ProcessorStage(AbstractStage):
                           )
         self.add_argument('-s', '--source', action='store', type=str,
                           nargs='?',
-                          help=u'Where to get data from: '
-                                'local (f)iles, (s)tdin, '
-                                '(h)dfs.',
+                          help=u'Where to get data from:\n'
+                                ' f -- local files\n'
+                                ' s -- stdin\n'
+                                ' h -- hdfs files\n',
                           default='f',
                           const='f',
                           choices=['f', 's', 'h'],
@@ -141,9 +142,10 @@ class ProcessorStage(AbstractStage):
                           dest='input_dir'
                           )
         self.add_argument('-d', '--dest', action='store', type=str, nargs='?',
-                          help=u'Where to send results: '
-                                'local (f)iles, (s)tdout, '
-                                '(h)dfs.',
+                          help=u'Where to write results:\n'
+                                ' f -- local files\n'
+                                ' s -- stdout\n'
+                                ' h -- hdfs files\n',
                           default='f',
                           const='f',
                           choices=['f', 's', 'h'],
@@ -152,15 +154,15 @@ class ProcessorStage(AbstractStage):
         self.add_argument('-o', '--output-dir', action='store', type=str,
                           nargs='?',
                           help=u'Directory for output files '
-                                '(local or HDFS). ',
+                                '(local or HDFS).',
                           default='out',
                           metavar='DIR',
                           dest='output_dir'
                           )
         self.add_argument('--hdfs', action='store_true',
-                          help=u'Equivalent to '
-                          '"--source h --dest h"; explicit specification of '
-                          '"--source" and "--dest", as well as the default '
+                          help=u'Equivalent to "--source h --dest h".\n'
+                          'Explicit specification of '
+                          '"--source" and "--dest" as well as the default '
                           'values for current processing mode ("--mode") will '
                           'be ignored.',
                           default=False,

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -121,9 +121,9 @@ class ProcessorStage(AbstractStage):
         self.add_argument('-s', '--source', action='store', type=str,
                           nargs='?',
                           help=u'where to get data from:\n'
-                                ' f -- local files\n'
-                                ' s -- stdin\n'
-                                ' h -- hdfs files\n',
+                                '    f -- local files\n'
+                                '    s -- stdin\n'
+                                '    h -- hdfs files',
                           default='f',
                           const='f',
                           choices=['f', 's', 'h'],
@@ -143,9 +143,9 @@ class ProcessorStage(AbstractStage):
                           )
         self.add_argument('-d', '--dest', action='store', type=str, nargs='?',
                           help=u'where to write results:\n'
-                                ' f -- local files\n'
-                                ' s -- stdout\n'
-                                ' h -- hdfs files\n',
+                                '    f -- local files\n'
+                                '    s -- stdout\n'
+                                '    h -- hdfs files',
                           default='f',
                           const='f',
                           choices=['f', 's', 'h'],

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -136,7 +136,7 @@ class ProcessorStage(AbstractStage):
                                 'If no FILE specified, all files with '
                                 'extension matching input message type will '
                                 'be taken from %(metavar)s',
-                          default='',
+                          default=None,
                           const='',
                           metavar='DIR',
                           dest='input_dir'

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -173,6 +173,9 @@ class ProcessorStage(AbstractStage):
         """
         if args:
             self.parse_args(args)
+        elif self.ARGS is None:
+            # Need to initialize ARGS to proceed
+            self.parse_args([])
         # Input
         self.__input = consumer.ConsumerBuilder(vars(self.ARGS)) \
             .setType(self.__input_message_type) \

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -119,40 +119,34 @@ class ProcessorStage(AbstractStage):
                           metavar=u'FILE'
                           )
         self.add_argument('-s', '--source', action='store', type=str,
-                          nargs='?',
                           help=u'where to get data from:\n'
                                 '    f -- local files\n'
                                 '    s -- stdin\n'
                                 '    h -- hdfs files',
                           default='f',
-                          const='f',
                           choices=['f', 's', 'h'],
                           dest='source'
                           )
         self.add_argument('-i', '--input-dir', action='store', type=str,
-                          nargs='?',
                           help=u'base directory in local file system '
                                 'or in HDFS (for relative FILE names). '
                                 'If no FILE specified, all files with '
                                 'extension matching input message type will '
                                 'be taken from %(metavar)s',
                           default=None,
-                          const='',
                           metavar='DIR',
                           dest='input_dir'
                           )
-        self.add_argument('-d', '--dest', action='store', type=str, nargs='?',
+        self.add_argument('-d', '--dest', action='store', type=str,
                           help=u'where to write results:\n'
                                 '    f -- local files\n'
                                 '    s -- stdout\n'
                                 '    h -- hdfs files',
                           default='f',
-                          const='f',
                           choices=['f', 's', 'h'],
                           dest='dest'
                           )
         self.add_argument('-o', '--output-dir', action='store', type=str,
-                          nargs='?',
                           help=u'directory for output files '
                                 '(local or HDFS)',
                           default='out',

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -132,8 +132,9 @@ class ProcessorStage(AbstractStage):
                           nargs='?',
                           help=u'Base directory in local file system '
                                 'or in HDFS (for relative FILE names). '
-                                'If no FILE specified, all files from the '
-                                'directory will be taken.',
+                                'If no FILE specified, all files with '
+                                'extension matching input message type will '
+                                'be taken from %(metavar)s.',
                           default='',
                           const='',
                           metavar='DIR',

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -115,12 +115,12 @@ class ProcessorStage(AbstractStage):
         """ Default parser configuration. """
         super(ProcessorStage, self).defaultArguments()
         self.add_argument('input_files', type=str, nargs='*',
-                          help=u'Source data file.',
+                          help=u'source data file',
                           metavar=u'FILE'
                           )
         self.add_argument('-s', '--source', action='store', type=str,
                           nargs='?',
-                          help=u'Where to get data from:\n'
+                          help=u'where to get data from:\n'
                                 ' f -- local files\n'
                                 ' s -- stdin\n'
                                 ' h -- hdfs files\n',
@@ -131,18 +131,18 @@ class ProcessorStage(AbstractStage):
                           )
         self.add_argument('-i', '--input-dir', action='store', type=str,
                           nargs='?',
-                          help=u'Base directory in local file system '
+                          help=u'base directory in local file system '
                                 'or in HDFS (for relative FILE names). '
                                 'If no FILE specified, all files with '
                                 'extension matching input message type will '
-                                'be taken from %(metavar)s.',
+                                'be taken from %(metavar)s',
                           default='',
                           const='',
                           metavar='DIR',
                           dest='input_dir'
                           )
         self.add_argument('-d', '--dest', action='store', type=str, nargs='?',
-                          help=u'Where to write results:\n'
+                          help=u'where to write results:\n'
                                 ' f -- local files\n'
                                 ' s -- stdout\n'
                                 ' h -- hdfs files\n',
@@ -153,18 +153,18 @@ class ProcessorStage(AbstractStage):
                           )
         self.add_argument('-o', '--output-dir', action='store', type=str,
                           nargs='?',
-                          help=u'Directory for output files '
-                                '(local or HDFS).',
+                          help=u'directory for output files '
+                                '(local or HDFS)',
                           default='out',
                           metavar='DIR',
                           dest='output_dir'
                           )
         self.add_argument('--hdfs', action='store_true',
-                          help=u'Equivalent to "--source h --dest h".\n'
+                          help=u'equivalent to "--source h --dest h".\n'
                           'Explicit specification of '
                           '"--source" and "--dest" as well as the default '
                           'values for current processing mode ("--mode") will '
-                          'be ignored.',
+                          'be ignored',
                           default=False,
                           dest='hdfs'
                           )


### PR DESCRIPTION
There were some issues with Stage:
* when running with empty cmdline arguments list;
* when interrupting stage, taking filenames from STDIN;
* when runnig with custom EOM, only first message was read.

The PR fixes these issues.

To check the behaviour I suggest to use test stage in `Utils/Dataflow/test/pyDKB`.
With which set of parameters to run this stage and what to expect [3]:

1. Local files:
- [x] without parameters (should claim that no input files specified);
- [x] `-m f` (should claim that no input files specified);
- [x] `-m f input/NDjson.json` (should produce output file `input/out/NDjson.ttl` [1] or claim that file exists);
- [x] ~~`input/NDjson.json` (should produce output file `input/out/NDjson.ttl` or claim that file exists)~~;
    *I believe that first two items shows that `-m f` and "without parameters" are the same, so 3rd and 4th are the same too.*
- [x] `-i ./input NDjson.json` (should produce output file `input/out/NDjson.ttl`  or claim that file exists);
- [x] `-i ./input` (should produce output file `input/out/NDjson.ttl` (or claim that file exists) and claim that fail reading messages from `jsonArray.json`);
- [x] `-o ./output input/NDjson.json` (should produce output file `output/NDjson.ttl` or claim that the file exists);
- [x] `-o output input/NDjson.json` (should produce output file `input/output/NDjson.ttl` or claim that the file exists);
- [x] `-d s input/NDjson.json` (should write output to STDOUT);
- [x] `-s s` (should take data from STDIN and write output to `out/???.ttl` files [2]);
2. HDFS files:
- [ ] `--hdfs` (should claim that no input files specified);
- [ ] `--hdfs /path/to/hdfs/file.json` (should produce output file `/path/to/hdfs/out/file.ttl` in HDFS or claim that the file already exists);
- [ ] `-m f --hdfs /path/to/hdfs/file.json` (should produce output file `/path/to/hdfs/out/file.ttl` in HDFS or claim that the file already exists);
- [ ] `-d h input/NDjson.json` (should produce output file `/user/DKB/temp/out/NDjson.ttl` in HDFS or claim that the file already exists);
- [ ] `-s h /path/to/hdfs/file.json` (should produce output file `out/file.ttl` or claim that the file already exists);
- [ ] `--hdfs -o /path/to/hdfs/dir /path/to/hdfs/file.json` (should produce output file `/path/to/hdfs/dir/file.ttl` in HDFS or claim that the file already exists);
- [ ] `-s h -i /path/to/hdfs file.json` (should process `hdfs:///path/to/hdfs/file.json` and produce local output file `out/file.ttl` or claim that the file already exists);
- [ ] `-s h -i /path/to/hdfs` (should produce local `out/*.ttl`output files in current directory for each `*.json` file from the HDFS directory or claim that the file already exists);
3. Streaming mode:
- [x] for every run in streaming mode (`-m s`) should add EOP marker to STDOUT;
- [x] `-m s` (should run in stream mode: take input data from STDIN and write output data to STDOUT);
- [x] `-m s -d f` (should take input data from STDIN and write output data to `./out/???.ttl` ( == `-s s` == `-m f -s s`));
- [ ] `-m s -d h` (should take input data from STDIN and write output data to `/user/DKB/temp/out/???.ttl` ( == `-s s -d h` == `--hdfs -s s`));
- [x] `-m s -s f` (should claim that no input files is specified ( == `-s f -d s` == `-d s` == `-m f -d s`));
- [ ] `-m s -s h` (should claim that no input files is specified ( == `-s h -d s` == `--hdfs -d s` == `-m f -s h -d s`));
4. MapReduce mode:
- [x] `-m m` (should run in MapReduce mode: take input data from STDIN (line by line) and write output data to STDOUT ( ~= `-m s`, except that no EOP marker appears in output);
- [x] `-m m -s s` (== `-m m`);
- [x] `-m m -d s` (== `-m m`);
- [ ] `-m m -s h` (should take input HDFS file names from STDIN and write output data to STDOUT);
- [ ] `-m m -d h` (should take input from STDIN and write output data to `/user/DKB/temp/out/???.ttl`);
- [ ] `-m m --hdfs` (should take input HDFS file names from STDIN and write output data to `/user/DKB/temp/out/???.ttl`);
- [x] `-m m -s f` (should claim that given source is not supported in (m)ap-reduce mode);
- [x] `-m m -d f` (should claim that given destination is not supported in (m)ap-reduce mode);
5. Custom EOP/EOM:
- [x] `-d s input/EOMDjson.json` (should fail to read input data);
- [x] `-d s -e EOM input/NDjson.json` (should fail to read input data);
- [x] `-d s -e EOM input/EOMDjson.json` (should output processed data to STDOUT with same EOM);
- [x] `-d s -E EOP input/NDjson.json` (should output EOP after every message);
- [x] `-d s -e '' input/jsonArray.json` (should output processed data to STDOUT, also in form of JSON array (or hash, if there\`s only one message)) [4];
- [x] `-d s -e '' input/NDjson.json` (should fail to read input data);

Not sure if this list is complete and that "expected" behaviour is intuitive, so if looking on cmdline parameters one expects different behaviour, please tell.

[1] `NDjson.ttl` must contain (Pythonic) string representation of JSON strings from `NDjson.json`.
[2] ??? is timestamp (seconds) of the moment when the filename is being chosen.
[3] Stage help message was changed to eliminate disputable moments; so everything said above is to be reviewd according to it.
~[4] Seems like there\`s a problem: if EOM == '', it allows to read JSON array -- but how output messages should be delimited? Maybe they should be collected into a single JSON array, too?~ (solved in PR #171)

---

ToDo:
- [x] rewrite checklist according to the new edition of the stage help message;
- [x] move help message improvements into a separate PR;
- [x] add input data sample with EOM other than `'\n'`;
- [x] add test utilities:
  - [x] to check ARGS parameter values after `*Stage.args_parse()`;
  - [x] to check expected behaviour of the stage as a whole;
- [x] fix everything not passing tests;
- [x] review changes;
- [ ] HDFS mode:
  - [ ] add tests;
  - [ ] fix everything that works not the way it is expected (or adjust expectations ;) );
  - [ ] review changes.

---
~Waits for: #149~ *(merged)*
Stage help/usage message changes are copied to a separate PR (#171) *(merged)*
Some of the errors are going to be fixed in #172 (re-refactoring).