### PR TITLE
ES query for prodtask-dev DKB web-interface

### DIFF
--- a/Utils/Elasticsearch/requests/deriv-ratio-q.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-q.json
@@ -15,7 +15,8 @@ GET tasks_production/task/_search
       "must": [
         {"term": {"primary_input": "aod"}},
         {"term": {"project": %%PROJECT_LOWERCASE%%}},
-        {"term": {"ctag": %%AMI_TAG_LOWERCASE%%}}
+        {"term": {"ctag": %%AMI_TAG_LOWERCASE%%}},
+        {"term": {"status": "done"}}
        ]
      }
    },

--- a/Utils/Elasticsearch/requests/deriv-ratio-q.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-q.json
@@ -16,18 +16,14 @@ GET tasks_production/task/_search
         {"term": {"primary_input": "aod"}},
         {"term": {"project": %%PROJECT_LOWERCASE%%}},
         {"term": {"ctag": %%AMI_TAG_LOWERCASE%%}},
-        {"term": {"status": "done"}}
+        {"term": {"status": "done"}},
+        {"range": {"input_bytes": {"gt": 0}}}   /* input dataset size > 0 */
        ]
      }
    },
   "aggs": {
-    "input": {
-      "filter": {"term": {"primary_input_deleted": false}},
-      "aggs": {
-        "bytes": {
-          "sum": {"field": "input_bytes"}
-        }
-      }
+    "input_bytes": {
+       "sum": {"field": "input_bytes"}
     },
     "output_datasets": {
       "children": {"type": "output_dataset"},

--- a/Utils/Elasticsearch/requests/deriv-ratio-q.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-q.json
@@ -1,0 +1,50 @@
+/*
+Get total size of task input and output datasets.
+
+Parameter values:
+  PROJECT_LOWERCASE -- project name ("mc16_13tev")
+  AMI_TAG_LOWERCASE -- current AMI tag for the task ("p3585")
+  FORMAT_UPPERCASE  -- output dataset data format ("DAOD_BPHY8")
+
+GET tasks_production/task/_search
+*/
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "must": [
+        {"term": {"primary_input": "aod"}},
+        {"term": {"project": %%PROJECT_LOWERCASE%%}},
+        {"term": {"ctag": %%AMI_TAG_LOWERCASE%%}}
+       ]
+     }
+   },
+  "aggs": {
+    "input": {
+      "filter": {"term": {"primary_input_deleted": false}},
+      "aggs": {
+        "bytes": {
+          "sum": {"field": "input_bytes"}
+        }
+      }
+    },
+    "output_datasets": {
+      "children": {"type": "output_dataset"},
+      "aggs": {
+        "not_removed": {
+          "filter": {"term": {"deleted": false}},
+          "aggs": {
+            "format": {
+              "filter": {"term": {"data_format": %%FORMAT_UPPERCASE%%}},
+              "aggs": {
+                "sum_bytes": {
+                  "sum": {"field": "bytes"}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Utils/Elasticsearch/requests/deriv-ratio-q.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-q.json
@@ -36,6 +36,9 @@ GET tasks_production/task/_search
     "input_bytes": {
        "sum": {"field": "input_bytes"}
     },
+    "input_events": {
+       "sum": {"field": "requested_events"}
+    },
     "output_datasets": {
       "children": {"type": "output_dataset"},
       "aggs": {
@@ -47,6 +50,9 @@ GET tasks_production/task/_search
               "aggs": {
                 "sum_bytes": {
                   "sum": {"field": "bytes"}
+                },
+                "sum_events": {
+                  "sum": {"field": "events"}
                 }
               }
             }

--- a/Utils/Elasticsearch/requests/deriv-ratio-q.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-q.json
@@ -17,10 +17,21 @@ GET tasks_production/task/_search
         {"term": {"project": %%PROJECT_LOWERCASE%%}},
         {"term": {"ctag": %%AMI_TAG_LOWERCASE%%}},
         {"term": {"status": "done"}},
-        {"range": {"input_bytes": {"gt": 0}}}   /* input dataset size > 0 */
-       ]
-     }
-   },
+        {"range": {"input_bytes": {"gt": 0}}},  /* input dataset size > 0 */
+        {"has_child": {                         /* task has output dataset... */
+            "type": "output_dataset",
+            "query" : {
+              "bool": {
+                "must": [
+                  {"term": {"data_format": %%FORMAT_UPPERCASE%%}},  /*...with proper data format */
+                  {"range": {"bytes": {"gt": 0}}}                   /* and size > 0 */
+                ]
+              }
+            }
+        }}
+      ]
+    }
+  },
   "aggs": {
     "input_bytes": {
        "sum": {"field": "input_bytes"}

--- a/Utils/Elasticsearch/requests/deriv-ratio-r.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-r.json
@@ -18,6 +18,9 @@
         "doc_count" : 3,
         "format" : {
           "doc_count" : 3,
+          "sum_events" : {
+            "value" : 590447.0
+          },
           "sum_bytes" : {
             "value" : 4.995767597E9
           }
@@ -26,6 +29,9 @@
     },
     "input_bytes" : {
       "value" : 1.91329808543E11
+    },
+    "input_events" : {
+      "value" : 1000000.0
     }
   }
 }

--- a/Utils/Elasticsearch/requests/deriv-ratio-r.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-r.json
@@ -7,15 +7,15 @@
     "failed" : 0
   },
   "hits" : {
-    "total" : 43,
+    "total" : 3,
     "max_score" : 0.0,
     "hits" : [ ]
   },
   "aggregations" : {
     "output_datasets" : {
-      "doc_count" : 43,
+      "doc_count" : 3,
       "not_removed" : {
-        "doc_count" : 43,
+        "doc_count" : 3,
         "format" : {
           "doc_count" : 3,
           "sum_bytes" : {
@@ -25,7 +25,7 @@
       }
     },
     "input_bytes" : {
-      "value" : 1.96896993909273E14
+      "value" : 1.91329808543E11
     }
   }
 }

--- a/Utils/Elasticsearch/requests/deriv-ratio-r.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-r.json
@@ -7,21 +7,21 @@
     "failed" : 0
   },
   "hits" : {
-    "total" : 4618,
+    "total" : 43,
     "max_score" : 0.0,
     "hits" : [ ]
   },
   "aggregations" : {
     "input" : {
-      "doc_count" : 4618,
+      "doc_count" : 43,
       "bytes" : {
-        "value" : 8.144762603257576E15
+        "value" : 1.96896993909273E14
       }
     },
     "output_datasets" : {
-      "doc_count" : 4618,
+      "doc_count" : 43,
       "not_removed" : {
-        "doc_count" : 4547,
+        "doc_count" : 43,
         "format" : {
           "doc_count" : 3,
           "sum_bytes" : {

--- a/Utils/Elasticsearch/requests/deriv-ratio-r.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-r.json
@@ -1,0 +1,34 @@
+{
+  "took" : 13,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 4,
+    "successful" : 4,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 4618,
+    "max_score" : 0.0,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "input" : {
+      "doc_count" : 4618,
+      "bytes" : {
+        "value" : 8.144762603257576E15
+      }
+    },
+    "output_datasets" : {
+      "doc_count" : 4618,
+      "not_removed" : {
+        "doc_count" : 4547,
+        "format" : {
+          "doc_count" : 3,
+          "sum_bytes" : {
+            "value" : 4.995767597E9
+          }
+        }
+      }
+    }
+  }
+}

--- a/Utils/Elasticsearch/requests/deriv-ratio-r.json
+++ b/Utils/Elasticsearch/requests/deriv-ratio-r.json
@@ -12,12 +12,6 @@
     "hits" : [ ]
   },
   "aggregations" : {
-    "input" : {
-      "doc_count" : 43,
-      "bytes" : {
-        "value" : 1.96896993909273E14
-      }
-    },
     "output_datasets" : {
       "doc_count" : 43,
       "not_removed" : {
@@ -29,6 +23,9 @@
           }
         }
       }
+    },
+    "input_bytes" : {
+      "value" : 1.96896993909273E14
     }
   }
 }


### PR DESCRIPTION
Suggested query returns total input / output dataset size and events number for tasks by parameters:
* project name;
* current AMI tag of the task;
* output dataset data format.

First it selects all documents of type 'task':
* status: 'done',
* primary_input: 'aod' (dataset name contains this term),
* project: parametric value,
* AMI tag: parametric value

...with following conditions:
* primary_input dataset size > 0,
* among output datasets there is a dataset with data in required format (parametric value), and its size is > 0.

Then found documents are aggregated:
* total input datasets size (sum),
* total input events sumber (sum),
* total output datasets size and events number for:
  * not deleted datasets
  * with data in given format.