### PR TITLE
es/query: add query to get statistics by task steps for hashtag.

### DIFF
--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -36,6 +36,9 @@ GET <index>/task/_search
         "cpu": {
           "sum": {"script": {"inline":"doc['hs06'].value * doc['total_events'].value"}}
         },
+        "walltime": {
+         "sum": {"script": {"inline":"doc['end_time'].value - doc['start_time'].value"}}
+        },
         "output": {
           "children": {"type": "output_dataset"},
           "aggs": {

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -37,7 +37,7 @@ GET <index>/task/_search
           "sum": {"script": {"inline":"doc['hs06'].value * doc['total_events'].value"}}
         },
         "walltime": {
-         "sum": {"script": {"inline":"doc['end_time'].value - doc['start_time'].value"}}
+         "avg": {"script": {"inline":"doc['end_time'].value - doc['start_time'].value"}}
         },
         "output": {
           "children": {"type": "output_dataset"},

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -34,7 +34,7 @@ GET <index>/task/_search
           "sum": {"field": "processed_events"}
         },
         "cpu": {
-          "sum": {"field": "hs06"}
+          "sum": {"script": {"inline":"doc['hs06'].value * doc['total_events'].value"}}
         },
         "output": {
           "children": {"type": "output_dataset"},

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -25,6 +25,9 @@ GET <index>/task/_search
         "input_bytes": {
           "sum": {"field": "input_bytes"}
         },
+        "processed_events": {
+          "sum": {"field": "processed_events"}
+        },
         "output": {
           "children": {"type": "output_dataset"},
           "aggs": {
@@ -33,9 +36,6 @@ GET <index>/task/_search
               "aggs": {
                 "bytes": {
                   "sum": {"field": "bytes"}
-                },
-                "events": {
-                  "sum": {"field": "events"}
                 }
               }
             }

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -1,7 +1,7 @@
 /* Get statistics for tasks with given hashtag by steps.
 
 Parameter values:
-  HASHTAG_LOWERCASE -- hashtag ("newfastcalosim")
+  HASHTAGS_LOWERCASE -- list of hashtags (["gammajets", "mc16c_cp"])
 
 GET <index>/task/_search
 */
@@ -10,7 +10,7 @@ GET <index>/task/_search
   "query": {
     "bool": {
       "must": [
-        {"term": {"hashtag_list": %%HASHTAG_LOWERCASE%%}},
+        {"terms": {"hashtag_list": %%HASHTAGS_LOWERCASE%%}},
         {"bool": {"must_not": [{"terms": {"status": ["aborted", "failed", "broken", "obsolete"]}}]}}
       ]
     }

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -22,8 +22,13 @@ GET <index>/task/_search
         "input_events": {
           "sum": {"field": "input_events"}
         },
-        "input_bytes": {
-          "sum": {"field": "input_bytes"}
+        "not_deleted": {
+          "filter": {"term": {"primary_input_deleted": false}},
+          "aggs": {
+            "input_bytes": {
+              "sum": {"field": "input_bytes"}
+            }
+          }
         },
         "processed_events": {
           "sum": {"field": "processed_events"}

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -33,6 +33,9 @@ GET <index>/task/_search
         "processed_events": {
           "sum": {"field": "processed_events"}
         },
+        "cpu": {
+          "sum": {"field": "hs06"}
+        },
         "output": {
           "children": {"type": "output_dataset"},
           "aggs": {

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -20,7 +20,7 @@ GET <index>/task/_search
       "terms": {"field": "step_name.keyword"},
       "aggs": {
         "input_events": {
-          "sum": {"field": "requested_events"}
+          "sum": {"field": "input_events"}
         },
         "input_bytes": {
           "sum": {"field": "input_bytes"}

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -1,7 +1,7 @@
 /* Get statistics for tasks with given hashtag by steps.
 
 Parameter values:
-  HASHTAG_LOWERCESE -- hashtag ("gammajets")
+  HASHTAG_LOWERCESE -- hashtag ("newfastcalosim")
 
 GET <index>/task/_search
 */
@@ -11,8 +11,7 @@ GET <index>/task/_search
     "bool": {
       "must": [
         {"term": {"hashtag_list": %%HASHTAG_LOWERCASE%%}},
-        {"term": {"status": "done"}},
-        {"term": {"primary_input_deleted": false}}
+        {"bool": {"must_not": [{"terms": {"status": ["aborted", "failed", "broken", "obsolete"]}}]}}
       ]
     }
   },
@@ -41,6 +40,9 @@ GET <index>/task/_search
               }
             }
           }
+        },
+        "status": {
+          "terms": {"field": "status"}
         }
       }
     }

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -36,8 +36,20 @@ GET <index>/task/_search
         "cpu": {
           "sum": {"script": {"inline":"doc['hs06'].value * doc['total_events'].value"}}
         },
-        "walltime": {
-         "avg": {"script": {"inline":"doc['end_time'].value - doc['start_time'].value"}}
+        "timestamp_defined": {
+          "filter": {
+            "bool": {
+              "must": [
+                {"exists": {"field": "start_time"}},
+                {"exists": {"field": "end_time"}}
+              ]
+            }
+          },
+          "aggs": {
+            "walltime": {
+              "avg": {"script": {"inline": "doc['end_time'].value - doc['start_time'].value"}}
+            }
+          }
         },
         "output": {
           "children": {"type": "output_dataset"},

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -1,0 +1,48 @@
+/* Get statistics for tasks with given hashtag by steps.
+
+Parameter values:
+  HASHTAG_LOWERCESE -- hashtag ("gammajets")
+
+GET <index>/task/_search
+*/
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "must": [
+        {"term": {"hashtag_list": %%HASHTAG_LOWERCASE%%}},
+        {"term": {"status": "done"}},
+        {"term": {"primary_input_deleted": false}}
+      ]
+    }
+  },
+  "aggs": {
+    "steps": {
+      "terms": {"field": "step_name.keyword"},
+      "aggs": {
+        "input_events": {
+          "sum": {"field": "requested_events"}
+        },
+        "input_bytes": {
+          "sum": {"field": "input_bytes"}
+        },
+        "output": {
+          "children": {"type": "output_dataset"},
+          "aggs": {
+            "not_removed": {
+              "filter": {"term": {"deleted": false}},
+              "aggs": {
+                "bytes": {
+                  "sum": {"field": "bytes"}
+                },
+                "events": {
+                  "sum": {"field": "events"}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-q.json
@@ -1,7 +1,7 @@
 /* Get statistics for tasks with given hashtag by steps.
 
 Parameter values:
-  HASHTAG_LOWERCESE -- hashtag ("newfastcalosim")
+  HASHTAG_LOWERCASE -- hashtag ("newfastcalosim")
 
 GET <index>/task/_search
 */

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
@@ -1,5 +1,5 @@
 {
-  "took" : 68,
+  "took" : 58,
   "timed_out" : false,
   "_shards" : {
     "total" : 4,
@@ -34,8 +34,11 @@
           "input_events" : {
             "value" : 2.5873E7
           },
-          "input_bytes" : {
-            "value" : 0.0
+          "not_deleted" : {
+            "doc_count" : 0,
+            "input_bytes" : {
+              "value" : 0.0
+            }
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -66,8 +69,11 @@
           "input_events" : {
             "value" : 2.5873E7
           },
-          "input_bytes" : {
-            "value" : -3192.0
+          "not_deleted" : {
+            "doc_count" : 0,
+            "input_bytes" : {
+              "value" : 0.0
+            }
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -98,8 +104,11 @@
           "input_events" : {
             "value" : 2.58726E7
           },
-          "input_bytes" : {
-            "value" : 3.478790311594E12
+          "not_deleted" : {
+            "doc_count" : 3192,
+            "input_bytes" : {
+              "value" : 3.478790311594E12
+            }
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -134,8 +143,11 @@
           "input_events" : {
             "value" : 2.5873E7
           },
-          "input_bytes" : {
-            "value" : 2.536129042E9
+          "not_deleted" : {
+            "doc_count" : 3192,
+            "input_bytes" : {
+              "value" : 2.536129042E9
+            }
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -170,8 +182,11 @@
           "input_events" : {
             "value" : 2.58726E7
           },
-          "input_bytes" : {
-            "value" : 5.591388107287E12
+          "not_deleted" : {
+            "doc_count" : 3192,
+            "input_bytes" : {
+              "value" : 5.591388107287E12
+            }
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
@@ -1,5 +1,5 @@
 {
-  "took" : 81,
+  "took" : 36,
   "timed_out" : false,
   "_shards" : {
     "total" : 4,
@@ -7,7 +7,7 @@
     "failed" : 0
   },
   "hits" : {
-    "total" : 15960,
+    "total" : 5047,
     "max_score" : 0.0,
     "hits" : [ ]
   },
@@ -17,173 +17,181 @@
       "sum_other_doc_count" : 0,
       "buckets" : [
         {
-          "key" : "Evgen",
-          "doc_count" : 3192,
+          "key" : "Simul",
+          "doc_count" : 890,
           "output" : {
-            "doc_count" : 3192,
+            "doc_count" : 890,
             "not_removed" : {
-              "doc_count" : 0,
+              "doc_count" : 802,
               "bytes" : {
-                "value" : 0.0
+                "value" : 1.843975252907852E15
               }
             }
           },
           "processed_events" : {
-            "value" : 2.5873E7
+            "value" : 3.11532E9
           },
           "input_events" : {
-            "value" : 2.5873E7
+            "value" : 3.12086314E9
           },
           "not_deleted" : {
-            "doc_count" : 0,
+            "doc_count" : 731,
             "input_bytes" : {
-              "value" : 0.0
+              "value" : 9.2578323257809E13
             }
           },
           "timestamp_defined" : {
-            "doc_count" : 3192,
+            "doc_count" : 890,
             "walltime" : {
-              "value" : 1.584503477443609E7
+              "value" : 1.665009702247191E9
             }
           },
           "cpu" : {
-            "value" : 0.0
+            "value" : 2.325882592729E13
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
             "sum_other_doc_count" : 0,
             "buckets" : [
               {
+                "key" : "finished",
+                "doc_count" : 466
+              },
+              {
                 "key" : "done",
-                "doc_count" : 3192
+                "doc_count" : 424
               }
             ]
           }
         },
         {
-          "key" : "Evgen Merge",
-          "doc_count" : 3192,
+          "key" : "Rec Merge",
+          "doc_count" : 874,
           "output" : {
-            "doc_count" : 3192,
+            "doc_count" : 874,
             "not_removed" : {
-              "doc_count" : 3192,
+              "doc_count" : 873,
               "bytes" : {
-                "value" : 2.536129042E9
+                "value" : 1.611510871873012E15
               }
             }
           },
           "processed_events" : {
-            "value" : 2.5873E7
+            "value" : 3.08715E9
           },
           "input_events" : {
-            "value" : 2.5873E7
+            "value" : 3.08856748E9
           },
           "not_deleted" : {
-            "doc_count" : 0,
+            "doc_count" : 69,
             "input_bytes" : {
-              "value" : 0.0
+              "value" : 1.25602037876142E14
             }
           },
           "timestamp_defined" : {
-            "doc_count" : 3192,
+            "doc_count" : 874,
             "walltime" : {
-              "value" : 9654426.065162906
+              "value" : 6.655076041189932E8
             }
           },
           "cpu" : {
-            "value" : 0.0
+            "value" : 2.899493302E10
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
             "sum_other_doc_count" : 0,
             "buckets" : [
               {
+                "key" : "finished",
+                "doc_count" : 479
+              },
+              {
                 "key" : "done",
-                "doc_count" : 3192
+                "doc_count" : 395
               }
             ]
           }
         },
         {
           "key" : "Reco",
-          "doc_count" : 3192,
+          "doc_count" : 874,
           "output" : {
-            "doc_count" : 3192,
+            "doc_count" : 874,
             "not_removed" : {
-              "doc_count" : 3192,
+              "doc_count" : 69,
               "bytes" : {
-                "value" : 5.591388107287E12
+                "value" : 1.25602037876142E14
               }
             }
           },
           "processed_events" : {
-            "value" : 2.58726E7
+            "value" : 3.08833E9
           },
           "input_events" : {
-            "value" : 2.58726E7
+            "value" : 3.08202245E9
           },
           "not_deleted" : {
-            "doc_count" : 3192,
+            "doc_count" : 874,
             "input_bytes" : {
-              "value" : 3.478790311594E12
+              "value" : 2.037608485347529E15
             }
           },
           "timestamp_defined" : {
-            "doc_count" : 3192,
+            "doc_count" : 874,
             "walltime" : {
-              "value" : 2.058583865914787E7
+              "value" : 1.0340005377574371E9
             }
           },
           "cpu" : {
-            "value" : 2.2972E8
+            "value" : 4.86700169899E12
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
             "sum_other_doc_count" : 0,
             "buckets" : [
               {
-                "key" : "done",
-                "doc_count" : 3188
+                "key" : "finished",
+                "doc_count" : 476
               },
               {
-                "key" : "finished",
-                "doc_count" : 4
+                "key" : "done",
+                "doc_count" : 398
               }
             ]
           }
         },
         {
-          "key" : "Simul",
-          "doc_count" : 3192,
+          "key" : "Evgen",
+          "doc_count" : 655,
           "output" : {
-            "doc_count" : 3192,
+            "doc_count" : 660,
             "not_removed" : {
-              "doc_count" : 3192,
+              "doc_count" : 346,
               "bytes" : {
-                "value" : 3.478790311594E12
+                "value" : 5.3438348330422E13
               }
             }
           },
           "processed_events" : {
-            "value" : 2.58726E7
+            "value" : 2.72312326E9
           },
           "input_events" : {
-            "value" : 2.5873E7
+            "value" : 2.72912464E9
           },
           "not_deleted" : {
-            "doc_count" : 3192,
+            "doc_count" : 0,
             "input_bytes" : {
-              "value" : 2.536129042E9
+              "value" : 0.0
             }
           },
           "timestamp_defined" : {
-            "doc_count" : 3192,
+            "doc_count" : 655,
             "walltime" : {
-              "value" : 7.758874436090225E7
+              "value" : 1.367617403053435E9
             }
           },
           "cpu" : {
-            "value" : 2.72266837E10
+            "value" : 9.70349375508E12
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -191,43 +199,43 @@
             "buckets" : [
               {
                 "key" : "done",
-                "doc_count" : 3188
+                "doc_count" : 383
               },
               {
                 "key" : "finished",
-                "doc_count" : 4
+                "doc_count" : 272
               }
             ]
           }
         },
         {
           "key" : "Deriv",
-          "doc_count" : 3192,
+          "doc_count" : 603,
           "output" : {
-            "doc_count" : 3192,
+            "doc_count" : 603,
             "not_removed" : {
-              "doc_count" : 3192,
+              "doc_count" : 281,
               "bytes" : {
-                "value" : 1.749292089875E12
+                "value" : 1.39618809E8
               }
             }
           },
           "processed_events" : {
-            "value" : 2.6436E7
+            "value" : 2.307705E9
           },
           "input_events" : {
-            "value" : 2.58726E7
+            "value" : 2.30159525E9
           },
           "not_deleted" : {
-            "doc_count" : 3192,
+            "doc_count" : 603,
             "input_bytes" : {
-              "value" : 5.591388107287E12
+              "value" : 1.184385227092671E15
             }
           },
           "timestamp_defined" : {
-            "doc_count" : 3192,
+            "doc_count" : 603,
             "walltime" : {
-              "value" : 1.5688471804511279E7
+              "value" : 1.8828026036484244E8
             }
           },
           "cpu" : {
@@ -238,12 +246,156 @@
             "sum_other_doc_count" : 0,
             "buckets" : [
               {
+                "key" : "finished",
+                "doc_count" : 334
+              },
+              {
                 "key" : "done",
-                "doc_count" : 3188
+                "doc_count" : 269
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Deriv Merge",
+          "doc_count" : 603,
+          "output" : {
+            "doc_count" : 603,
+            "not_removed" : {
+              "doc_count" : 603,
+              "bytes" : {
+                "value" : 3.0760037E7
+              }
+            }
+          },
+          "processed_events" : {
+            "value" : 2.3465E9
+          },
+          "input_events" : {
+            "value" : 2.3465E9
+          },
+          "not_deleted" : {
+            "doc_count" : 281,
+            "input_bytes" : {
+              "value" : 1.39618809E8
+            }
+          },
+          "timestamp_defined" : {
+            "doc_count" : 603,
+            "walltime" : {
+              "value" : 2.2072077943615258E7
+            }
+          },
+          "cpu" : {
+            "value" : 0.0
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "finished",
+                "doc_count" : 334
+              },
+              {
+                "key" : "done",
+                "doc_count" : 269
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Evgen Merge",
+          "doc_count" : 456,
+          "output" : {
+            "doc_count" : 456,
+            "not_removed" : {
+              "doc_count" : 456,
+              "bytes" : {
+                "value" : 4.7421588396214E13
+              }
+            }
+          },
+          "processed_events" : {
+            "value" : 1.99189304E9
+          },
+          "input_events" : {
+            "value" : 1.99189804E9
+          },
+          "not_deleted" : {
+            "doc_count" : 142,
+            "input_bytes" : {
+              "value" : 2.4121442024259E13
+            }
+          },
+          "timestamp_defined" : {
+            "doc_count" : 456,
+            "walltime" : {
+              "value" : 2.708991030701754E8
+            }
+          },
+          "cpu" : {
+            "value" : 2.44529493E9
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 308
               },
               {
                 "key" : "finished",
-                "doc_count" : 4
+                "doc_count" : 148
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Merge",
+          "doc_count" : 92,
+          "output" : {
+            "doc_count" : 92,
+            "not_removed" : {
+              "doc_count" : 92,
+              "bytes" : {
+                "value" : 1.97013536056331E14
+              }
+            }
+          },
+          "processed_events" : {
+            "value" : 3.2440795E8
+          },
+          "input_events" : {
+            "value" : 3.2461535E8
+          },
+          "not_deleted" : {
+            "doc_count" : 4,
+            "input_bytes" : {
+              "value" : 7.743374148466E12
+            }
+          },
+          "timestamp_defined" : {
+            "doc_count" : 92,
+            "walltime" : {
+              "value" : 1.375414695652174E9
+            }
+          },
+          "cpu" : {
+            "value" : 2.76126855E9
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "finished",
+                "doc_count" : 72
+              },
+              {
+                "key" : "done",
+                "doc_count" : 20
               }
             ]
           }

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
@@ -7,7 +7,7 @@
     "failed" : 0
   },
   "hits" : {
-    "total" : 464,
+    "total" : 15956,
     "max_score" : 0.0,
     "hits" : [ ]
   },
@@ -17,91 +17,191 @@
       "sum_other_doc_count" : 0,
       "buckets" : [
         {
-          "key" : "Reco",
-          "doc_count" : 214,
+          "key" : "Evgen",
+          "doc_count" : 3192,
           "output" : {
-            "doc_count" : 214,
+            "doc_count" : 3192,
             "not_removed" : {
-              "doc_count" : 0,
+              "doc_count" : 3192,
               "bytes" : {
-                "value" : 0.0
+                "value" : 2.700194325E9
               },
               "events" : {
-                "value" : 0.0
+                "value" : 2.5871E7
               }
             }
           },
           "input_events" : {
-            "value" : 2.9716E8
+            "value" : 0.0
           },
           "input_bytes" : {
-            "value" : 2.11976417118351E14
-          }
-        },
-        {
-          "key" : "Deriv",
-          "doc_count" : 126,
-          "output" : {
-            "doc_count" : 126,
-            "not_removed" : {
-              "doc_count" : 0,
-              "bytes" : {
-                "value" : 0.0
+            "value" : 0.0
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 3191
               },
-              "events" : {
-                "value" : 0.0
+              {
+                "key" : "submitting",
+                "doc_count" : 1
               }
-            }
-          },
-          "input_events" : {
-            "value" : 1.541E8
-          },
-          "input_bytes" : {
-            "value" : 3.6577966348884E13
-          }
-        },
-        {
-          "key" : "Simul",
-          "doc_count" : 92,
-          "output" : {
-            "doc_count" : 92,
-            "not_removed" : {
-              "doc_count" : 88,
-              "bytes" : {
-                "value" : 8.8762676532185E13
-              },
-              "events" : {
-                "value" : 1.284325E8
-              }
-            }
-          },
-          "input_events" : {
-            "value" : 1.30813E8
-          },
-          "input_bytes" : {
-            "value" : 3.513445272751E12
+            ]
           }
         },
         {
           "key" : "Evgen Merge",
-          "doc_count" : 32,
+          "doc_count" : 3192,
           "output" : {
-            "doc_count" : 32,
+            "doc_count" : 3192,
             "not_removed" : {
-              "doc_count" : 32,
+              "doc_count" : 3192,
               "bytes" : {
-                "value" : 8.27471114712E11
+                "value" : 2.536129042E9
               },
               "events" : {
-                "value" : 2.7988E7
+                "value" : 2.5873E7
               }
             }
           },
           "input_events" : {
-            "value" : 2.7993E7
+            "value" : 2.5873E7
           },
           "input_bytes" : {
-            "value" : 8.31437218336E11
+            "value" : 2.700102371E9
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 3192
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Reco",
+          "doc_count" : 3191,
+          "output" : {
+            "doc_count" : 3191,
+            "not_removed" : {
+              "doc_count" : 3190,
+              "bytes" : {
+                "value" : 5.57884150685E12
+              },
+              "events" : {
+                "value" : 2.58686E7
+              }
+            }
+          },
+          "input_events" : {
+            "value" : 2.58706E7
+          },
+          "input_bytes" : {
+            "value" : 3.478883059238E12
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 3186
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 4
+              },
+              {
+                "key" : "running",
+                "doc_count" : 1
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Simul",
+          "doc_count" : 3191,
+          "output" : {
+            "doc_count" : 3191,
+            "not_removed" : {
+              "doc_count" : 3191,
+              "bytes" : {
+                "value" : 3.46991560003E12
+              },
+              "events" : {
+                "value" : 2.58706E7
+              }
+            }
+          },
+          "input_events" : {
+            "value" : 2.5871E7
+          },
+          "input_bytes" : {
+            "value" : 2.535908959E9
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 3187
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 4
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Deriv",
+          "doc_count" : 3190,
+          "output" : {
+            "doc_count" : 3189,
+            "not_removed" : {
+              "doc_count" : 3188,
+              "bytes" : {
+                "value" : 1.737231647933E12
+              },
+              "events" : {
+                "value" : 0.0
+              }
+            }
+          },
+          "input_events" : {
+            "value" : 2.643E7
+          },
+          "input_bytes" : {
+            "value" : 5.576948660775E12
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 3184
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 4
+              },
+              {
+                "key" : "registered",
+                "doc_count" : 1
+              },
+              {
+                "key" : "running",
+                "doc_count" : 1
+              }
+            ]
           }
         }
       ]

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
@@ -1,0 +1,110 @@
+{
+  "took" : 53,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 4,
+    "successful" : 4,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 464,
+    "max_score" : 0.0,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "steps" : {
+      "doc_count_error_upper_bound" : 0,
+      "sum_other_doc_count" : 0,
+      "buckets" : [
+        {
+          "key" : "Reco",
+          "doc_count" : 214,
+          "output" : {
+            "doc_count" : 214,
+            "not_removed" : {
+              "doc_count" : 0,
+              "bytes" : {
+                "value" : 0.0
+              },
+              "events" : {
+                "value" : 0.0
+              }
+            }
+          },
+          "input_events" : {
+            "value" : 2.9716E8
+          },
+          "input_bytes" : {
+            "value" : 2.11976417118351E14
+          }
+        },
+        {
+          "key" : "Deriv",
+          "doc_count" : 126,
+          "output" : {
+            "doc_count" : 126,
+            "not_removed" : {
+              "doc_count" : 0,
+              "bytes" : {
+                "value" : 0.0
+              },
+              "events" : {
+                "value" : 0.0
+              }
+            }
+          },
+          "input_events" : {
+            "value" : 1.541E8
+          },
+          "input_bytes" : {
+            "value" : 3.6577966348884E13
+          }
+        },
+        {
+          "key" : "Simul",
+          "doc_count" : 92,
+          "output" : {
+            "doc_count" : 92,
+            "not_removed" : {
+              "doc_count" : 88,
+              "bytes" : {
+                "value" : 8.8762676532185E13
+              },
+              "events" : {
+                "value" : 1.284325E8
+              }
+            }
+          },
+          "input_events" : {
+            "value" : 1.30813E8
+          },
+          "input_bytes" : {
+            "value" : 3.513445272751E12
+          }
+        },
+        {
+          "key" : "Evgen Merge",
+          "doc_count" : 32,
+          "output" : {
+            "doc_count" : 32,
+            "not_removed" : {
+              "doc_count" : 32,
+              "bytes" : {
+                "value" : 8.27471114712E11
+              },
+              "events" : {
+                "value" : 2.7988E7
+              }
+            }
+          },
+          "input_events" : {
+            "value" : 2.7993E7
+          },
+          "input_bytes" : {
+            "value" : 8.31437218336E11
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
@@ -1,5 +1,5 @@
 {
-  "took" : 58,
+  "took" : 81,
   "timed_out" : false,
   "_shards" : {
     "total" : 4,
@@ -40,6 +40,15 @@
               "value" : 0.0
             }
           },
+          "timestamp_defined" : {
+            "doc_count" : 3192,
+            "walltime" : {
+              "value" : 1.584503477443609E7
+            }
+          },
+          "cpu" : {
+            "value" : 0.0
+          },
           "status" : {
             "doc_count_error_upper_bound" : 0,
             "sum_other_doc_count" : 0,
@@ -75,6 +84,15 @@
               "value" : 0.0
             }
           },
+          "timestamp_defined" : {
+            "doc_count" : 3192,
+            "walltime" : {
+              "value" : 9654426.065162906
+            }
+          },
+          "cpu" : {
+            "value" : 0.0
+          },
           "status" : {
             "doc_count_error_upper_bound" : 0,
             "sum_other_doc_count" : 0,
@@ -109,6 +127,15 @@
             "input_bytes" : {
               "value" : 3.478790311594E12
             }
+          },
+          "timestamp_defined" : {
+            "doc_count" : 3192,
+            "walltime" : {
+              "value" : 2.058583865914787E7
+            }
+          },
+          "cpu" : {
+            "value" : 2.2972E8
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -149,6 +176,15 @@
               "value" : 2.536129042E9
             }
           },
+          "timestamp_defined" : {
+            "doc_count" : 3192,
+            "walltime" : {
+              "value" : 7.758874436090225E7
+            }
+          },
+          "cpu" : {
+            "value" : 2.72266837E10
+          },
           "status" : {
             "doc_count_error_upper_bound" : 0,
             "sum_other_doc_count" : 0,
@@ -187,6 +223,15 @@
             "input_bytes" : {
               "value" : 5.591388107287E12
             }
+          },
+          "timestamp_defined" : {
+            "doc_count" : 3192,
+            "walltime" : {
+              "value" : 1.5688471804511279E7
+            }
+          },
+          "cpu" : {
+            "value" : 0.0
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,

--- a/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
+++ b/Utils/Elasticsearch/requests/hashtag-steps-statistics-r.json
@@ -1,5 +1,5 @@
 {
-  "took" : 53,
+  "took" : 68,
   "timed_out" : false,
   "_shards" : {
     "total" : 4,
@@ -7,7 +7,7 @@
     "failed" : 0
   },
   "hits" : {
-    "total" : 15956,
+    "total" : 15960,
     "max_score" : 0.0,
     "hits" : [ ]
   },
@@ -22,17 +22,17 @@
           "output" : {
             "doc_count" : 3192,
             "not_removed" : {
-              "doc_count" : 3192,
+              "doc_count" : 0,
               "bytes" : {
-                "value" : 2.700194325E9
-              },
-              "events" : {
-                "value" : 2.5871E7
+                "value" : 0.0
               }
             }
           },
+          "processed_events" : {
+            "value" : 2.5873E7
+          },
           "input_events" : {
-            "value" : 0.0
+            "value" : 2.5873E7
           },
           "input_bytes" : {
             "value" : 0.0
@@ -43,11 +43,7 @@
             "buckets" : [
               {
                 "key" : "done",
-                "doc_count" : 3191
-              },
-              {
-                "key" : "submitting",
-                "doc_count" : 1
+                "doc_count" : 3192
               }
             ]
           }
@@ -61,17 +57,17 @@
               "doc_count" : 3192,
               "bytes" : {
                 "value" : 2.536129042E9
-              },
-              "events" : {
-                "value" : 2.5873E7
               }
             }
+          },
+          "processed_events" : {
+            "value" : 2.5873E7
           },
           "input_events" : {
             "value" : 2.5873E7
           },
           "input_bytes" : {
-            "value" : 2.700102371E9
+            "value" : -3192.0
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -86,24 +82,24 @@
         },
         {
           "key" : "Reco",
-          "doc_count" : 3191,
+          "doc_count" : 3192,
           "output" : {
-            "doc_count" : 3191,
+            "doc_count" : 3192,
             "not_removed" : {
-              "doc_count" : 3190,
+              "doc_count" : 3192,
               "bytes" : {
-                "value" : 5.57884150685E12
-              },
-              "events" : {
-                "value" : 2.58686E7
+                "value" : 5.591388107287E12
               }
             }
           },
+          "processed_events" : {
+            "value" : 2.58726E7
+          },
           "input_events" : {
-            "value" : 2.58706E7
+            "value" : 2.58726E7
           },
           "input_bytes" : {
-            "value" : 3.478883059238E12
+            "value" : 3.478790311594E12
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -111,39 +107,35 @@
             "buckets" : [
               {
                 "key" : "done",
-                "doc_count" : 3186
+                "doc_count" : 3188
               },
               {
                 "key" : "finished",
                 "doc_count" : 4
-              },
-              {
-                "key" : "running",
-                "doc_count" : 1
               }
             ]
           }
         },
         {
           "key" : "Simul",
-          "doc_count" : 3191,
+          "doc_count" : 3192,
           "output" : {
-            "doc_count" : 3191,
+            "doc_count" : 3192,
             "not_removed" : {
-              "doc_count" : 3191,
+              "doc_count" : 3192,
               "bytes" : {
-                "value" : 3.46991560003E12
-              },
-              "events" : {
-                "value" : 2.58706E7
+                "value" : 3.478790311594E12
               }
             }
           },
+          "processed_events" : {
+            "value" : 2.58726E7
+          },
           "input_events" : {
-            "value" : 2.5871E7
+            "value" : 2.5873E7
           },
           "input_bytes" : {
-            "value" : 2.535908959E9
+            "value" : 2.536129042E9
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -151,7 +143,7 @@
             "buckets" : [
               {
                 "key" : "done",
-                "doc_count" : 3187
+                "doc_count" : 3188
               },
               {
                 "key" : "finished",
@@ -162,24 +154,24 @@
         },
         {
           "key" : "Deriv",
-          "doc_count" : 3190,
+          "doc_count" : 3192,
           "output" : {
-            "doc_count" : 3189,
+            "doc_count" : 3192,
             "not_removed" : {
-              "doc_count" : 3188,
+              "doc_count" : 3192,
               "bytes" : {
-                "value" : 1.737231647933E12
-              },
-              "events" : {
-                "value" : 0.0
+                "value" : 1.749292089875E12
               }
             }
           },
+          "processed_events" : {
+            "value" : 2.6436E7
+          },
           "input_events" : {
-            "value" : 2.643E7
+            "value" : 2.58726E7
           },
           "input_bytes" : {
-            "value" : 5.576948660775E12
+            "value" : 5.591388107287E12
           },
           "status" : {
             "doc_count_error_upper_bound" : 0,
@@ -187,19 +179,11 @@
             "buckets" : [
               {
                 "key" : "done",
-                "doc_count" : 3184
+                "doc_count" : 3188
               },
               {
                 "key" : "finished",
                 "doc_count" : 4
-              },
-              {
-                "key" : "registered",
-                "doc_count" : 1
-              },
-              {
-                "key" : "running",
-                "doc_count" : 1
               }
             ]
           }


### PR DESCRIPTION
Currently query returns:
* total size of input datasets;
* total number of requested events;
* total size of output datasets;
* total number of events in output datasets;
* number of tasks by task status.

for:
* tasks with given hashtag;
* with all statuses but:
  * aborted;
  * failed;
  * broken;
  * obsolete;
* aggregated by step;
* for not deleted output datasets.

The example response is given for "gammajets" hashtag.