### PR TITLE
Stage 019: markers

### DIFF
--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -7,7 +7,7 @@ set_error_handler("exception_error_handler");
 
 $DEFAULT_INDEX = 'tasks_production';
 $ES_INDEX = NULL;
-$EOP_MARKER = '';
+$EOP_MARKER = chr(0);
 $EOM_MARKER = "\n";
 
 function check_input($row) {

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -73,7 +73,7 @@ foreach ($opts as $key => $val) {
     unset($args[$mkey]);
     unset($args[$mkey+1]);
   }
-  $match = preg_grep("/^".$key."=/", $args);
+  $match = preg_grep("/^-(-)?".$key."=/", $args);
   foreach ($match as $mkey => $mval) {
     unset($args[$mkey]);
   }

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -7,6 +7,8 @@ set_error_handler("exception_error_handler");
 
 $DEFAULT_INDEX = 'tasks_production';
 $ES_INDEX = NULL;
+$EOP_MARKER = '';
+$EOM_MARKER = "\n";
 
 function check_input($row) {
   $required_fields = array('_id', '_type');
@@ -82,7 +84,9 @@ if ($h) {
     $index = constructIndexJson($row);
 
     echo json_encode($index)."\n";
-    echo json_encode($row)."\n";
+    echo json_encode($row);
+    echo $EOM_MARKER;
+    echo $EOP_MARKER;
   }
 }
 

--- a/Utils/Dataflow/019_esFormat/run.sh
+++ b/Utils/Dataflow/019_esFormat/run.sh
@@ -4,10 +4,11 @@ base_dir=$(cd "$(dirname "$(readlink -f "$0")")"; pwd)
 
 usage() {
   echo "USAGE:
-$(basename "$0") [-c CONFIG]
+$(basename "$0") [-c CONFIG] [--] [ARGS]
   
 PARAMETERS:
   CONFIG -- configuration file
+  ARGS   -- arguments to be passed to the PHP script
 "
 }
 
@@ -21,10 +22,6 @@ while [ -n "$1" ]; do
     --)
       shift
       break;;
-    -*)
-      echo "Unknown option: $1" >&2
-      usage >&2
-      exit 1;;
     *)
       break;;
   esac
@@ -39,4 +36,4 @@ set -a
   . "$ES_CONFIG"
 set +a
 
-$base_dir/esFormat.php
+$base_dir/esFormat.php "$@"

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -209,7 +209,7 @@ sink_chain() {
   [ -n "$DEBUG" ] \
     && cmd="tee 69.$1.inp" \
     || cmd=$cmd_69
-  $cmd_19 | mediator "$1" | $cmd > /dev/null
+  $cmd_19 | eop_filter | mediator "$1" | $cmd > /dev/null
 }
 
 out=/dev/null


### PR DESCRIPTION
Suddenly realized that processing stage 019_esFormat does not follow the EOM/EOP marker paradigm.
For now it is OK, but when we switch to Kafka-supervised version of the dataflow, it will be embarassing to find out the stage does not support basic communication protocol.

ToDo:
- [x] add command line parameters '-e|--end-of-message' and '-E|--end-of-process'.