### PR TITLE
docs/pyDKB: fix docstrings

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/communication/messages.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/messages.py
@@ -89,7 +89,7 @@ class AbstractMessage(object):
 
     @classmethod
     def extension(cls):
-        """ Return file extension corresponding this message type. """
+        """ Return file extension corresponding to this message type. """
         return cls._ext
 
 

--- a/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/ProcessorStage.py
@@ -57,7 +57,7 @@ from pyDKB.dataflow.communication import producer
 class ProcessorStage(AbstractStage):
     """ Abstract class to implement Processor stages
 
-    Processor stage -- is a stage for data processing/transfornation.
+    Processor stage -- is a stage for data processing/transformation.
 
     Class/instance variable description:
 


### PR DESCRIPTION
Fix docstring in `dataflow.communication.messages`.

[WIP] is to leave it as PR for a while, before we start to bring order to the whole `pyDKB` documentation.