### PR TITLE
Revert PR #149

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py
@@ -22,6 +22,9 @@ from .. import Message
 class FileConsumer(Consumer.Consumer):
     """ Data consumer implementation for HDFS data source. """
 
+    # Input file names (iterable object)
+    input_filenames = None
+
     # Current file
     current_file = None
 
@@ -58,11 +61,6 @@ class FileConsumer(Consumer.Consumer):
         """ Return current source info. """
         return self.current_file
 
-    def init_sources(self):
-        """ Initialize sources iterator if not initialized yet. """
-        if not self.input_files:
-            self.input_files = self._input_files()
-
     def get_source(self):
         """ Get nearest non-empty source (current or next). """
         if self.source_is_empty() is not False:
@@ -79,7 +77,7 @@ class FileConsumer(Consumer.Consumer):
             None (no files left)
         """
         if not self.input_files:
-            self.init_sources()
+            self.input_files = self._input_files()
         try:
             self.current_file = self.input_files.next()
             result = self.get_source()
@@ -114,9 +112,9 @@ class FileConsumer(Consumer.Consumer):
                 if os.path.isfile(os.path.join(dirname, f)) \
                         and f.lower().endswith(ext):
                     files.append(f)
-                    yield f
         except OSError, err:
             raise Consumer.ConsumerException(err)
+        return files
 
     def _adjusted_filenames(self):
         """ Return iterable object, yielding filename and path to file. """

--- a/Utils/Dataflow/pyDKB/dataflow/communication/stream/InputStream.py
+++ b/Utils/Dataflow/pyDKB/dataflow/communication/stream/InputStream.py
@@ -25,7 +25,7 @@ class InputStream(Stream):
         if self.EOM == '\n':
             self.__iterator = iter(fd.readline, "")
         elif self.EOM == '':
-            self.__iterator = iter(fd.read, "")
+            self.__iterator = iter([fd.read()])
         else:
             self.__iterator = custom_readline(fd, self.EOM)
 
@@ -35,7 +35,10 @@ class InputStream(Stream):
         Overrides parent method to reset __iterator property.
         """
         super(InputStream, self).reset(fd, close)
-        self._reset_iterator()
+        # Not _reset_iterator(), as we are not sure someone
+        # will ask for new messages -- then why read the whole file
+        # in advance (if EOM appears to be '')?
+        self.__iterator = None
 
     def parse_message(self, message):
         """ Verify and parse input message.


### PR DESCRIPTION
This reverts commit f4b04cc481a504859fd7468dcc6326fa0f821766, reversing
changes made (by branch 'pyDKB-refactoring') to
d5259c0252d2876b0e57804a7de230237acc46f9 (branch 'pyDKB').

The revert is required as PR #149 introduced a bug, due to which any
stage program failed on start at least in `stream` mode:
```
Utils/Dataflow/test/pyDKB$ ./json2TTL.py -m s
(WARN) pyDKB.dataflow.cds failed (No module named
invenio_client.contrib)
Traceback (most recent call last):
  File "./json2TTL.py", line 75, in <module>
    main(sys.argv[1:])
  File "./json2TTL.py", line 56, in main
    stage.configure(args)
  File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line 178, in
configure
    .setType(self.__input_message_type) \
  File "./../../pyDKB/dataflow/communication/consumer/__init__.py", line
62, in build
    instance = self.consumerClass(config)
  File "./../../pyDKB/dataflow/communication/consumer/Consumer.py", line
33, in __init__
    self.reconfigure()
  File
"./../../pyDKB/dataflow/communication/consumer/StreamConsumer.py", line
27, in reconfigure
    super(StreamConsumer, self).reconfigure(config)
  File "./../../pyDKB/dataflow/communication/consumer/Consumer.py", line
61, in reconfigure
    self.init_stream()
  File "./../../pyDKB/dataflow/communication/consumer/Consumer.py", line
70, in init_stream
    .setType(self.message_type) \
  File "./../../pyDKB/dataflow/communication/stream/__init__.py", line
71, in build
    instance = self.streamClass(self.fd, config)
  File "./../../pyDKB/dataflow/communication/stream/Stream.py", line 20,
in __init__
    self.reset(fd)
  File "./../../pyDKB/dataflow/communication/stream/InputStream.py",
line 38, in reset
    self._reset_iterator()
  File "./../../pyDKB/dataflow/communication/stream/InputStream.py",
line 25, in _reset_iterator
    if self.EOM == '\n':
```

Conflicts:
	Utils/Dataflow/pyDKB/dataflow/communication/consumer/FileConsumer.py