### PR TITLE
pyDKB setup script

### DIFF
--- a/Utils/Dataflow/.gitignore
+++ b/Utils/Dataflow/.gitignore
@@ -1,0 +1,1 @@
+pyDKB.egg-info/

--- a/Utils/Dataflow/.gitignore
+++ b/Utils/Dataflow/.gitignore
@@ -1,1 +1,3 @@
 pyDKB.egg-info/
+build/
+dist/

--- a/Utils/Dataflow/pyDKB-setup.py
+++ b/Utils/Dataflow/pyDKB-setup.py
@@ -2,4 +2,6 @@
 
 import setuptools
 
-setuptools.setup(name='pyDKB')
+setuptools.setup(name='pyDKB',
+                 packages=setuptools.find_packages(),
+                 package_data={'pyDKB.dataflow': ['dkbID.conf']})

--- a/Utils/Dataflow/pyDKB-setup.py
+++ b/Utils/Dataflow/pyDKB-setup.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python
 
 import setuptools
+import os
 
-setuptools.setup(name='pyDKB',
+package = 'pyDKB'
+basedir = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(basedir, package, 'VERSION')) as version_file:
+    version = version_file.read().strip()
+
+setuptools.setup(name=package,
+                 version=version,
                  packages=setuptools.find_packages(),
-                 package_data={'pyDKB.dataflow': ['dkbID.conf']})
+                 package_data={'pyDKB.dataflow': ['dkbID.conf'],
+                               'pyDKB': ['VERSION']})

--- a/Utils/Dataflow/pyDKB-setup.py
+++ b/Utils/Dataflow/pyDKB-setup.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+import setuptools
+
+setuptools.setup(name='pyDKB')

--- a/Utils/Dataflow/pyDKB/VERSION
+++ b/Utils/Dataflow/pyDKB/VERSION
@@ -1,0 +1,1 @@
+0.3-SNAPSHOT

--- a/Utils/Dataflow/pyDKB/__init__.py
+++ b/Utils/Dataflow/pyDKB/__init__.py
@@ -5,6 +5,11 @@ Common library for Data Knowledge Base development.
 import dataflow
 import common
 
-__version__ = "0.3-SNAPSHOT"
+import os
+
+
+basedir = os.path.dirname(__file__)
+with open(os.path.join(basedir, 'VERSION')) as version_file:
+    __version__ = version_file.read().strip()
 
 __all__ = ["dataflow"]


### PR DESCRIPTION
Add simple setup script to avoid dancing around `sys.path`.

To install the `pyDKB` library for the development, run `./pyDKB-setup.py develop`.
It will fake-install library, creating link to the directory with source
files, and there will be no need to re-install library after every
change.

To install `pyDKB` "for usage", use `./pyDKB-setup.py install`.

ToDo:
 - [x] version definition (to have same version in `setup` and `__install__`)