### PR TITLE
[WIP] Hashtag-based derivation tasks statistics

### DIFF
--- a/Utils/Elasticsearch/requests/hashtag-deriv-statistic-q.json
+++ b/Utils/Elasticsearch/requests/hashtag-deriv-statistic-q.json
@@ -1,0 +1,96 @@
+/* Get statistics for derivation tasks with given hashtag and AMI tag by output formats.
+
+Parameter values:
+  HASHTAGS_LOWERCASE -- list of hashtags (["gammajets", "newfastcalosim"])
+  AMI_TAGS_LOWERCASE -- list of AMI tags (["p3127", "p3126"])
+  FORMAT_* -- formats, fitting given AMI tag(s) ("NTUP_PILEUP", "NTUP_FCS")
+
+GET <index>/task/_search
+*/
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "must": [
+        {"terms": {"hashtag_list": %%HASHTAGS_LOWERCASE%%}},
+        {"terms": {"ctag": %%AMI_TAGS_LOWERCASE%%}},
+        {"bool": {"must_not": [{"terms": {"status": ["aborted", "failed", "broken", "obsolete"]}}]}},
+        {"term": {"primary_input": "aod"}}
+      ]
+    }
+  },
+  "aggs": {
+    "formats": {
+      "filters": {
+        "filters": {
+          %%FORMAT_1%%: {
+            "has_child": {
+              "type": "output_dataset",
+              "query": {"term": {"data_format": %%FORMAT_1%%}}
+            }
+          },
+          %%FORMAT_2%%: {
+            "has_child": {
+              "type": "output_dataset",
+              "query": {"term": {"data_format": %%FORMAT_2%%}}
+            }
+          }
+/*        , %%FORMAT_3%% { ... }, ...
+*/
+        }
+      },
+      "aggs": {
+        "status": {
+          "terms": {"field": "status"},
+          "aggs": {
+            "input_events": {
+              "sum": {"field": "input_events"}
+            },
+            "not_deleted": {
+              "filter": {"term": {"primary_input_deleted": false}},
+              "aggs": {
+                "input_bytes": {
+                  "sum": {"field": "input_bytes"}
+                }
+              }
+            },
+            "processed_events": {
+              "sum": {"field": "processed_events"}
+            },
+            "cpu": {
+              "sum": {"script": {"inline":"doc['hs06'].value * doc['total_events'].value"}}
+            },
+            "timestamp_defined": {
+              "filter": {
+                "bool": {
+                  "must": [
+                    {"exists": {"field": "start_time"}},
+                    {"exists": {"field": "end_time"}}
+                  ]
+                }
+              },
+              "aggs": {
+                "walltime": {
+                  "avg": {"script": {"inline": "doc['end_time'].value - doc['start_time'].value"}}
+                }
+              }
+            },
+            "output": {
+              "children": {"type": "output_dataset"},
+              "aggs": {
+                "not_removed": {
+                  "filter": {"term": {"deleted": false}},
+                  "aggs": {
+                    "bytes": {
+                      "sum": {"field": "bytes"}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Utils/Elasticsearch/requests/hashtag-deriv-statistic-r.json
+++ b/Utils/Elasticsearch/requests/hashtag-deriv-statistic-r.json
@@ -1,0 +1,105 @@
+{
+  "took" : 100,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 4,
+    "successful" : 4,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 164,
+    "max_score" : 0.0,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "formats" : {
+      "buckets" : {
+        "NTUP_FCS" : {
+          "doc_count" : 0,
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [ ]
+          }
+        },
+        "NTUP_PILEUP" : {
+          "doc_count" : 164,
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 120,
+                "output" : {
+                  "doc_count" : 120,
+                  "not_removed" : {
+                    "doc_count" : 0,
+                    "bytes" : {
+                      "value" : 0.0
+                    }
+                  }
+                },
+                "processed_events" : {
+                  "value" : 1.5128E8
+                },
+                "input_events" : {
+                  "value" : 1.4622544E8
+                },
+                "not_deleted" : {
+                  "doc_count" : 120,
+                  "input_bytes" : {
+                    "value" : 3.583454135229E13
+                  }
+                },
+                "timestamp_defined" : {
+                  "doc_count" : 120,
+                  "walltime" : {
+                    "value" : 8.519630833333333E7
+                  }
+                },
+                "cpu" : {
+                  "value" : 0.0
+                }
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 44,
+                "output" : {
+                  "doc_count" : 44,
+                  "not_removed" : {
+                    "doc_count" : 0,
+                    "bytes" : {
+                      "value" : 0.0
+                    }
+                  }
+                },
+                "processed_events" : {
+                  "value" : 1.842E8
+                },
+                "input_events" : {
+                  "value" : 1.8513315E8
+                },
+                "not_deleted" : {
+                  "doc_count" : 44,
+                  "input_bytes" : {
+                    "value" : 3.9453061823527E13
+                  }
+                },
+                "timestamp_defined" : {
+                  "doc_count" : 44,
+                  "walltime" : {
+                    "value" : 5.562912045454545E8
+                  }
+                },
+                "cpu" : {
+                  "value" : 0.0
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added query to get hashtag-based derivation tasks statistics.

The query gets information:
 * aggregated by output data formats;
 * within formats -- aggregated by task status;
 * for each format+status bucket:
   * total number of input events;
   * total size of input datasets;
   * total number of output events;
   * total size of output datasets;
   * average task walltime;
   * estimated total cpu time.

Questions:
 - [ ] parameters combination to get more demonstrative output.