### PR TITLE
DF/09: fix issue with empty start/end time config values.

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -163,6 +163,9 @@ def config_get(config, section, param, default=None):
                              % (param, section, default))
         result = default
 
+    if result == '' and default is not None:
+        result = default
+
     return result
 
 


### PR DESCRIPTION
Initially it was decided that if a parameter is specified in the config
file, then it should not be treated as "not specified" even if it has
empty value, and left with empty string value.

However I made same mistakes multiple times already, leaving the
parameter when I meant "not specified", like:
```
[timestamps]
initial =
final = 01-03-2014 00:00:00
...
```

So I decided that if we are aware about the default values for a
parameter, than it should not be expected to have "empty string" value
whenever it is used.

If one day we shall need the empty string, it will be solved in its
turn.