### PR TITLE
Stage 009 update

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -41,6 +41,7 @@ def main():
 
     # read initial configuration
     config = read_config(args.config)
+    config['mode'] = mode
     log_config(config)
     if config is None:
         sys.exit(1)

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -46,7 +46,7 @@ def main():
     if not offset_storage:
         sys.exit(2)
 
-    conn = OracleConnection(config['dsn'])
+    conn = OracleConnection(config['__dsn'])
     if not conn.establish():
         sys.stderr.write("(ERROR) Failed to connect to Oracle. Exiting.\n")
         sys.exit(3)
@@ -99,7 +99,7 @@ def read_config(config_file):
     try:
         config.read(config_file)
         # Required parameters (with no defaults)
-        result['dsn'] = config.get('oracle', 'dsn')
+        result['__dsn'] = config.get('oracle', 'dsn')
         step = config.get('timestamps', 'step')
         result['step_seconds'] = interval_seconds(step)
         if result['step_seconds'] == 0:

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -74,7 +74,8 @@ def log_config(config):
     if not isinstance(config, dict):
         sys.stderr.write("(ERROR) Stage is misconfigured.\n")
 
-    sys.stderr.write("(INFO) Stage 009 configuration:\n")
+    sys.stderr.write("(INFO) Stage 009 configuration (%s):\n"
+                     % config['__file__'])
 
     key_len = len(max(config.keys(), key=len))
     pattern = "(INFO)  %%-%ds : '%%s'\n" % key_len
@@ -97,6 +98,7 @@ def read_config(config_file):
     :rtype: dict|NoneType
     """
     result = {'__path__': os.path.dirname(os.path.abspath(config_file))}
+    result['__file__'] = os.path.join(result['__path__'], config_file)
     config = ConfigParser.SafeConfigParser()
     try:
         config.read(config_file)

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -17,8 +17,6 @@ SQUASH_POLICY = 'SQUASH'
 
 # Global variables
 # ---
-# Operating mode
-mode = None
 # Output stream
 OUT = os.fdopen(sys.stdout.fileno(), 'w', 0)
 # ---
@@ -36,12 +34,10 @@ def main():
        Query: SELECT min(timestamp) from t_production_task;
     """
     args = parsingArguments()
-    global mode
-    mode = args.mode
 
     # read initial configuration
     config = read_config(args.config)
-    config['mode'] = mode
+    config['mode'] = args.mode
     log_config(config)
     if config is None:
         sys.exit(1)
@@ -438,6 +434,7 @@ def process(conn, offset_storage, config):
     :type offset_storage: OffsetStorage
     :type config: dict
     """
+    mode = config['mode']
     reverse = config['step_seconds'] < 0
     final_date = config['final_date']
     step_seconds = config['step_seconds']

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -26,7 +26,7 @@ def main():
     """ Main program cycle.
 
     USAGE:
-       ./Oracle2JSON.py --config <config file> --mode <PLAIN|SQUASH>
+       ./Oracle2JSON.py --config <config file>
 
     TODO:
        Obtain the min(timestamp) from t_production_task
@@ -37,7 +37,6 @@ def main():
 
     # read initial configuration
     config = read_config(args.config)
-    config['mode'] = args.mode
     log_config(config)
     if config is None:
         sys.exit(1)
@@ -140,6 +139,7 @@ def read_config(config_file):
     result['offset_file'] = config_path(config_get(config, 'logging',
                                                    'offset_file', '.offset'),
                                         result)
+    result['mode'] = config_get(config, 'process', 'mode', 'SQUASH')
 
     return result
 
@@ -537,8 +537,6 @@ def parsingArguments():
                                      " connector stage.")
     parser.add_argument('--config', help="Configuration file path",
                         type=str, required=True)
-    parser.add_argument('--mode', help="Mode of execution: PLAIN | SQUASH",
-                        choices=[PLAIN_POLICY, SQUASH_POLICY])
     args = parser.parse_args()
     if not os.access(args.config, os.F_OK):
         sys.stderr.write("argument --config: '%s' file not exists\n"

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -41,6 +41,7 @@ def main():
 
     # read initial configuration
     config = read_config(args.config)
+    log_config(config)
     if config is None:
         sys.exit(1)
 
@@ -60,6 +61,29 @@ def main():
         sys.exit(1)
 
     process(conn, offset_storage, config)
+
+
+def log_config(config):
+    """ Log stage configuration.
+
+    :param config: stage configuration
+    :type config: dict, NoneType
+    """
+    if config is None:
+        sys.stderr.write("(ERROR) Stage is not configured.\n")
+    if not isinstance(config, dict):
+        sys.stderr.write("(ERROR) Stage is misconfigured.\n")
+
+    sys.stderr.write("(INFO) Stage 009 configuration:\n")
+
+    key_len = len(max(config.keys(), key=len))
+    pattern = "(INFO)  %%-%ds : '%%s'\n" % key_len
+    sys.stderr.write("(INFO) ---\n")
+    for p in config:
+        if p.startswith('__'):
+            continue
+        sys.stderr.write(pattern % (p, config[p]))
+    sys.stderr.write("(INFO) ---\n")
 
 
 def read_config(config_file):

--- a/Utils/Dataflow/009_oracleConnector/README
+++ b/Utils/Dataflow/009_oracleConnector/README
@@ -35,6 +35,13 @@ tasks: query/prodsys2ES.sql
 # relative path to datasets query
 datasets: query/datasets.sql
 
+[process]
+# Query response processing mode:
+#  PLAIN   -- pass records to output independently of each other
+#  SQUASH  -- link 'datasets' records to 'task', joining them into a single
+#             record
+mode = SQUASH
+
 [timestamps]
 # initial timestamp
 initial = 04-03-2014 00:00:00

--- a/Utils/Dataflow/config/009.cfg.example
+++ b/Utils/Dataflow/config/009.cfg.example
@@ -20,6 +20,13 @@ datasets: %__009_query_dir__%/datasets.sql
 # * = -- analysis
 production_or_analysis_cond = >
 
+[process]
+# Query response processing mode:
+#  PLAIN   -- pass records to output independently of each other
+#  SQUASH  -- link 'datasets' records to 'task', joining them into a single
+#             record
+mode = SQUASH
+
 [timestamps]
 # initial timestamp (e.g. 01-05-2016 00:00:00)
 initial = %__009_init_offset__%

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -56,7 +56,7 @@ get_config() {
 # Oracle Connector
 cmd_09="${base_dir}/../009_oracleConnector/Oracle2JSON.py"
 cfg_09=`get_config "009.cfg"`
-cmd_OC="$cmd_09 --config $cfg_09 --mode SQUASH"
+cmd_OC="$cmd_09 --config $cfg_09"
 
 # Stage 25
 cmd_25="${base_dir}/../025_chicagoES/stage.py -m s"


### PR DESCRIPTION
Two main changes:
* added logging of the stage configuration at startup;
* 'mode' (SQUASH|PLAIN) parameter was moved from command line to the config file.

Now the startup log looks like this:
```
$ ./Oracle2JSON.py --config ./config 
(INFO) Config: parameter 'initial' (section 'timestamps') is not configured. Using default value: 2019-01-23 12:13:32.585796
(INFO) Stage 009 configuration (/home/dkb/dkb-dev.git/Utils/Dataflow/009_oracleConnector/./config):
(INFO) ---
(INFO)  step_seconds : '-3600'
(INFO)  initial_date : '2019-01-23 12:13:32.585796'
(INFO)  offset_file  : '/home/dkb/dkb-dev.git/Utils/Dataflow/009_oracleConnector/.offset'
(INFO)  mode         : 'SQUASH'
(INFO)  queries      : '{'tasks': {'params': {'production_or_analysis_cond': '>'}, 'file': '/home/dkb/dkb-test.git/Utils/Dataflow/009_oracleConnector/query/prodsys2ES.sql'}, 'datasets': {'params': {'production_or_analysis_cond': '>'}, 'file': '/home/dkb/dkb-test.git/Utils/Dataflow/009_oracleConnector/query/datasets.sql'}}'
(INFO)  final_date   : '2019-01-23 00:00:00'
(INFO) ---
(INFO) Establish connection to the DB...
(INFO) Connection established.
(TRACE) 23-01-2019 12:13:32: Run queries for interval from ...
```