### PR TITLE
Stage 009 config example's duplicate.

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/README
+++ b/Utils/Dataflow/009_oracleConnector/README
@@ -24,37 +24,7 @@ To run `prodsys2ES` query only, use PLAIN mode:
 
   ./oracle2JSON.py --config $CONFIG --mode PLAIN
 
-The configuration file:
-```
-[oracle]
-dsn: USER/PASSWORD@HOST:PORT/SERVICE_NAME
+A template for the configuration file can be obtained in Dataflow's
+corresponding directory:
 
-[queries]
-# relative path to tasks query
-tasks: query/prodsys2ES.sql
-# relative path to datasets query
-datasets: query/datasets.sql
-
-[process]
-# Query response processing mode:
-#  PLAIN   -- pass records to output independently of each other
-#  SQUASH  -- link 'datasets' records to 'task', joining them into a single
-#             record
-mode = SQUASH
-
-[timestamps]
-# initial timestamp
-initial = 04-03-2014 00:00:00
-# final timestamp
-final = 10-05-2016 00:00:00
-# hours offset from current timestamp
-step = 24h
-
-[logging]
-# Current offset file
-# (relative to the dir with the config file or absolute path)
-# offset_file = .offset
-```
-
-Current offset by default is stored in the same directory as the config file,
-  but it can be configured.
+  Utils/Dataflow/config/009.cfg.example


### PR DESCRIPTION
Currently there are two examples of the config file for the stage - the one in `Utils/Dataflow/config/` is more up to date, so the one in stage 009's readme is replaced with a link to the former.

Noticeable difference between the two examples is the description of the change introduced in bef4178 -
`Utils/Dataflow/config/009.cfg.example` was updated, but 009's readme was not. Because of this, using the readme's config for launching the stage would lead to failure due to missing query parametric values.