### PR TITLE
DF/009: fix README (remove obsolete cmdline '--mode' explaination).

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/README
+++ b/Utils/Dataflow/009_oracleConnector/README
@@ -15,14 +15,9 @@ The goal is to make it work with any number and combination of queries.
 
 2. HowTo
 --------
-To run `prodsys2ES` and `datasets` queries and join the results, use
-  SQUASH mode:
+To run stage, use:
 
-  ./oracle2JSON.py --config $CONFIG --mode SQUASH
-
-To run `prodsys2ES` query only, use PLAIN mode:
-
-  ./oracle2JSON.py --config $CONFIG --mode PLAIN
+  ./oracle2JSON.py --config CONFIG
 
 A template for the configuration file can be obtained in Dataflow's
 corresponding directory:

--- a/Utils/Dataflow/config/009.cfg.example
+++ b/Utils/Dataflow/config/009.cfg.example
@@ -23,6 +23,7 @@ production_or_analysis_cond = >
 [process]
 # Query response processing mode:
 #  PLAIN   -- pass records to output independently of each other
+#             (currently: 'tasks' query only)
 #  SQUASH  -- link 'datasets' records to 'task', joining them into a single
 #             record
 mode = SQUASH


### PR DESCRIPTION
The parameter was removed in PR #193 (b97dc7a), but not all the docs
were updated there.

Config file example is updates to keep information about the fact that
'PLAIN' mode currently works only with 'tasks' query.