### PR TITLE
Stage 009: Improve query saving procedure.

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/dbConnection.py
+++ b/Utils/Dataflow/009_oracleConnector/dbConnection.py
@@ -117,8 +117,8 @@ class OracleConnection(dbConnection):
     def save_query_file(self, qname, src_filename, params=None):
         """ Read query from file and save it in query hash. """
         try:
-            f = open(src_filename)
-            q = f.read().rstrip().rstrip(';')
+            with open(src_filename) as f:
+                q = f.read().rstrip().rstrip(';')
             if isinstance(params, dict):
                 q = q % params
             elif '%' in q.replace('%%', ''):

--- a/Utils/Dataflow/009_oracleConnector/dbConnection.py
+++ b/Utils/Dataflow/009_oracleConnector/dbConnection.py
@@ -124,8 +124,9 @@ class OracleConnection(dbConnection):
             elif '%(' in q:
                 # Check for '%(' is done because a valid query without
                 # parameters (and their configuration) is possible.
-                sys.stderr.write("(WARN) No query parameters were configured "
-                                 "for '%s'. This can result in "
+                sys.stderr.write("(WARN) '%s': query seems to be parametric, "
+                                 "but no query parameters were configured. "
+                                 "This can result in "
                                  "'ORA-00911' error.\n" % qname)
             self.queries[qname]['query'] = q
         except IOError, err:

--- a/Utils/Dataflow/009_oracleConnector/dbConnection.py
+++ b/Utils/Dataflow/009_oracleConnector/dbConnection.py
@@ -121,8 +121,8 @@ class OracleConnection(dbConnection):
                 q = f.read().rstrip().rstrip(';')
             if isinstance(params, dict):
                 q = q % params
-            elif '%' in q.replace('%%', ''):
-                # Check for single '%' is done because a valid query without
+            elif '%(' in q:
+                # Check for '%(' is done because a valid query without
                 # parameters (and their configuration) is possible.
                 sys.stderr.write("(WARN) No query parameters were configured "
                                  "for '%s'. This can result in "

--- a/Utils/Dataflow/009_oracleConnector/dbConnection.py
+++ b/Utils/Dataflow/009_oracleConnector/dbConnection.py
@@ -121,9 +121,20 @@ class OracleConnection(dbConnection):
             q = f.read().rstrip().rstrip(';')
             if isinstance(params, dict):
                 q = q % params
+            elif '%' in q.replace('%%', ''):
+                # Check for single '%' is done because a valid query without
+                # parameters (and their configuration) is possible.
+                sys.stderr.write("(WARN) No parameters were configured "
+                                 "for '%s' query. This can result in "
+                                 "'ORA-00911' error.\n" % qname)
             self.queries[qname]['query'] = q
         except IOError, err:
             sys.stderr.write("(ERROR) Failed to read query file: %s\n" % err)
+            return False
+        except KeyError, err:
+            sys.stderr.write("(ERROR) Failed to update query: expected "
+                             "parameter %s not found in the "
+                             "configuration.\n" % err)
             return False
 
         return True

--- a/Utils/Dataflow/009_oracleConnector/dbConnection.py
+++ b/Utils/Dataflow/009_oracleConnector/dbConnection.py
@@ -124,17 +124,15 @@ class OracleConnection(dbConnection):
             elif '%' in q.replace('%%', ''):
                 # Check for single '%' is done because a valid query without
                 # parameters (and their configuration) is possible.
-                sys.stderr.write("(WARN) No parameters were configured "
-                                 "for '%s' query. This can result in "
+                sys.stderr.write("(WARN) No query parameters were configured "
+                                 "for '%s'. This can result in "
                                  "'ORA-00911' error.\n" % qname)
             self.queries[qname]['query'] = q
         except IOError, err:
             sys.stderr.write("(ERROR) Failed to read query file: %s\n" % err)
             return False
         except KeyError, err:
-            sys.stderr.write("(ERROR) Failed to update query: expected "
-                             "parameter %s not found in the "
-                             "configuration.\n" % err)
+            sys.stderr.write("(ERROR) Query parameter missing: %s\n" % err)
             return False
 
         return True

--- a/Utils/Dataflow/config/009.cfg.example
+++ b/Utils/Dataflow/config/009.cfg.example
@@ -8,7 +8,7 @@ tasks: %__009_query_dir__%/prodsys2ES.sql
 datasets: %__009_query_dir__%/datasets.sql
 
 [queries.params]
-# Parametric values for all queries:
+# Query parameters for all queries:
 # string '%(<param_name>)s' in sql file will be replaced
 # with the value of <param_name> (if value is quoted, quotes
 # will appear in the query as well).


### PR DESCRIPTION
Problems with error handling:

- A single missing parameter leads to KeyError. Add interception for it
to display a message that points to the configuration.
- The whole configuration missing leads to (even more puzzling)
ORA-00911. Add a warning when no parameters were configured that also
points towards configuration. Since it is possible to use a query
without parameters, no warning should be displayed in such case. Add
a check to only display the warning when the query contains single '%'
(double percent '%%' means that '%' was escaped, so it's allowed).

Also, a file is opened but not closed in the function - fixed that.