### PR TITLE
pyDKB stage fix (pt.17)

### DIFF
--- a/Utils/Dataflow/test/pyDKB/README
+++ b/Utils/Dataflow/test/pyDKB/README
@@ -27,13 +27,15 @@ input/      -- input samples.
 
 To run test cases, use:
 
-  ./test.sh [-h] [-l] [-c N[,N...]] [--todo]
+  ./test.sh [-h] [-l [TYPE]] [-c N[,N...]] [--todo]
 
   Run pyDKB stage functionality test cases.
 
   OPTIONS
     -h, --help    show this message and exit
-    -l, --list    show test cases description
+    -l, --list [TYPE]
+                  show test case information: description by default,
+                  TYPE if specified
     -c, --case N[,N...]
                   run specified test case(s)
     --todo        list known issues for improvements

--- a/Utils/Dataflow/test/pyDKB/README
+++ b/Utils/Dataflow/test/pyDKB/README
@@ -27,7 +27,7 @@ input/      -- input samples.
 
 To run test cases, use:
 
-  ./test.sh [-h] [-l [TYPE]] [-c N[,N...]]
+  ./test.sh [-h] [-l [TYPE] [--no-info]] [-c N[,N...]]
 
   Run pyDKB stage functionality test cases.
 
@@ -36,6 +36,7 @@ To run test cases, use:
     -l, --list [TYPE]
                   show test case information: description by default,
                   TYPE if specified
+    --no-info     don't show case descriptions with --list command
     -c, --case N[,N...]
                   run specified test case(s)
 

--- a/Utils/Dataflow/test/pyDKB/README
+++ b/Utils/Dataflow/test/pyDKB/README
@@ -27,7 +27,7 @@ input/      -- input samples.
 
 To run test cases, use:
 
-  ./test.sh [-h] [-l [TYPE]] [-c N[,N...]] [--todo]
+  ./test.sh [-h] [-l [TYPE]] [-c N[,N...]]
 
   Run pyDKB stage functionality test cases.
 
@@ -38,7 +38,6 @@ To run test cases, use:
                   TYPE if specified
     -c, --case N[,N...]
                   run specified test case(s)
-    --todo        list known issues for improvements
 
 
 Dummy stage can be run as follows:

--- a/Utils/Dataflow/test/pyDKB/test.sh
+++ b/Utils/Dataflow/test/pyDKB/test.sh
@@ -12,13 +12,15 @@ orig_dir=`pwd`
 cd $base_dir
 
 usage() {
-  echo "$0 [-h] [-l] [-c N[,N...]] [--todo]
+  echo "$0 [-h] [-l [TYPE]] [-c N[,N...]] [--todo]
 
 Run pyDKB stage functionality test cases.
 
 OPTIONS
   -h, --help    show this message and exit
-  -l, --list    show test cases description
+  -l, --list [TYPE]
+                show test case information: description by default,
+                TYPE if specified
   -c, --case N[,N...]
                 run specified test case(s)
   --todo        list known issues for improvements
@@ -31,10 +33,9 @@ list_case() {
     if [ -f "$c/$info" ] || [ -z "$info" ]; then
       echo -n "`basename "$c"`: "
       cat "$c/info"
-      if [ -n "$info" ]; then
-        echo "--- ${info^^} ---"
-        cat "$c/$info"
-        echo -e "------------\n"
+      if [ -n "$info" ] && [ "$info" != 'info' ] ; then
+        cat "$c/$info" | sed 's/^/    /'
+        echo ""
       fi
     fi
   done
@@ -80,7 +81,9 @@ CASES=""
 while [ -n "$1" ]; do
   case "$1" in
     -l|--list)
-      list_case
+      ( [ -z "$2" ] || [[ "$2" = -* ]] ) && INFO=info || \
+        { INFO="$2"; shift; }
+      list_case "$INFO"
       exit 0
       ;;
     -h|--help)

--- a/Utils/Dataflow/test/pyDKB/test.sh
+++ b/Utils/Dataflow/test/pyDKB/test.sh
@@ -12,7 +12,7 @@ orig_dir=`pwd`
 cd $base_dir
 
 usage() {
-  echo "$0 [-h] [-l [TYPE]] [-c N[,N...]]
+  echo "$0 [-h] [-l [TYPE] [--no-info]] [-c N[,N...]]
 
 Run pyDKB stage functionality test cases.
 
@@ -21,6 +21,7 @@ OPTIONS
   -l, --list [TYPE]
                 show test case information: description by default,
                 TYPE if specified
+  --no-info     don't show case descriptions with --list command
   -c, --case N[,N...]
                 run specified test case(s)
 " >&2
@@ -31,10 +32,11 @@ list_case() {
   for c in "case/"*; do
     if [ -f "$c/$info" ] || [ -z "$info" ]; then
       echo -n "`basename "$c"`: "
-      cat "$c/info"
+      [ -z "$NO_INFO" ] && cat "$c/info"
       if [ -n "$info" ] && [ "$info" != 'info' ] ; then
-        cat "$c/$info" | sed 's/^/    /'
-        echo ""
+        [ -n "$NO_INFO" ] && sed_cmd='1!s/^/    /' || sed_cmd='s/^/    /'
+        cat "$c/$info" | sed "$sed_cmd"
+        [ -z "$NO_INFO" ] && echo ""
       fi
     fi
   done
@@ -82,8 +84,6 @@ while [ -n "$1" ]; do
     -l|--list)
       ( [ -z "$2" ] || [[ "$2" = -* ]] ) && INFO=info || \
         { INFO="$2"; shift; }
-      list_case "$INFO"
-      exit 0
       ;;
     -h|--help)
       usage && exit 0
@@ -95,6 +95,9 @@ while [ -n "$1" ]; do
       CASES=`echo "case/$2" | sed -e's/,/ case\//g'`
       shift
       ;;
+    --no-info)
+      NO_INFO=1
+      ;;
     -*)
       echo "Unknown option: $1" && usage && exit 1
       ;;
@@ -104,6 +107,11 @@ while [ -n "$1" ]; do
   esac
   shift
 done
+
+if [ -n "$INFO" ]; then
+  list_case "$INFO"
+  exit 0
+fi
 
 [ -z "$CASES" ] && CASES='case/*'
 

--- a/Utils/Dataflow/test/pyDKB/test.sh
+++ b/Utils/Dataflow/test/pyDKB/test.sh
@@ -12,7 +12,7 @@ orig_dir=`pwd`
 cd $base_dir
 
 usage() {
-  echo "$0 [-h] [-l [TYPE]] [-c N[,N...]] [--todo]
+  echo "$0 [-h] [-l [TYPE]] [-c N[,N...]]
 
 Run pyDKB stage functionality test cases.
 
@@ -23,7 +23,6 @@ OPTIONS
                 TYPE if specified
   -c, --case N[,N...]
                 run specified test case(s)
-  --todo        list known issues for improvements
 " >&2
 }
 
@@ -95,10 +94,6 @@ while [ -n "$1" ]; do
              "(use --help for usage info)." >&2 && exit 1
       CASES=`echo "case/$2" | sed -e's/,/ case\//g'`
       shift
-      ;;
-    --todo)
-      list_case todo
-      exit 0
       ;;
     -*)
       echo "Unknown option: $1" && usage && exit 1


### PR DESCRIPTION
Test utility improvements:
* `--list` -> `--list [TYPE]` (allows to output specific type of test case information: `todo`, `cmd`, ...);
* `--todo` removed (as it is replaced with `--list todo`);
* `--no-info` (allows to skip test cases description and output only information of specific `TYPE`).

---
+ (pt.16) #218 