### PR TITLE
pyDKB stage fix (pt.22)

### DIFF
--- a/Utils/Dataflow/test/pyDKB/test.sh
+++ b/Utils/Dataflow/test/pyDKB/test.sh
@@ -52,7 +52,7 @@ test_case() {
   after=`cat $case/after 2>/dev/null`
 
   eval "$before $cmd; $after"  2>&1 1> out.tmp | \
-    grep -v '(WARN) pyDKB.dataflow.cds failed (No module named invenio_client.contrib)' | \
+    grep -a -v '(WARN) pyDKB.dataflow.cds failed (No module named invenio_client.contrib)' | \
     sed -e"s#$base_dir#\$base_dir#" >  err.tmp
 
   err_correct=0


### PR DESCRIPTION
Add `-a` parameter to `grep` command to avoid "Binary file matches." in
the output (instead of the expected lines of STDERR).

---
* pt.21 (#223)