### PR TITLE
API/setup: improve Nginx config file for DKB API sever.

### DIFF
--- a/Utils/API/server/nginx.dkb.conf
+++ b/Utils/API/server/nginx.dkb.conf
@@ -7,8 +7,6 @@ server {
             access_log /var/log/nginx/dkb.access.log main;
             error_log  /var/log/nginx/dkb.error.log;
             fastcgi_pass  unix:%%SOCK%%;
-            fastcgi_index index.py;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param QUERY_STRING    $query_string;
+            include /etc/nginx/fastcgi_params;
   }
 }


### PR DESCRIPTION
Usually Nginx has the pre-defined list of fcgi parameters, and we have
no reason to avoid it in favor of our own list (that can be shorter, but
we will always have something forgotten...)