### PR TITLE
API: /task/chain method

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2'
+__version__ = '0.2.dev20190320'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -111,3 +111,20 @@ def task_hist(path, **kwargs):
 
 
 methods.add('/task', 'hist', task_hist)
+
+
+def task_chain(path, **kwargs):
+    """ Get list of tasks belonging to same chain as ``tid``.
+
+    :param path: full path to the method
+    :type path: str
+    :param tid: task id
+    :type tid: str, int
+
+    :return: list of Task IDs, ordered from first to last task in chain
+    :rtype: dict
+    """
+    raise DkbApiNotImplemented
+
+
+methods.add('/task', 'chain', task_chain)

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -132,7 +132,7 @@ def task_chain(path, **kwargs):
         int(tid)
     except ValueError:
         raise InvalidArgument(method_name, ('tid', tid, int))
-    raise DkbApiNotImplemented
+    return storages.task_chain(**kwargs)
 
 
 methods.add('/task', 'chain', task_chain)

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -124,6 +124,14 @@ def task_chain(path, **kwargs):
     :return: list of Task IDs, ordered from first to last task in chain
     :rtype: dict
     """
+    method_name = '/task/chain'
+    tid = kwargs.get('tid', None)
+    if tid is None:
+        raise MissedArgument(method_name, 'tid')
+    try:
+        int(tid)
+    except ValueError:
+        raise InvalidArgument(method_name, ('tid', tid, int))
     raise DkbApiNotImplemented
 
 

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -35,3 +35,20 @@ def task_steps_hist(**kwargs):
     :rtype: dict
     """
     return es.task_steps_hist(**kwargs)
+
+
+def task_chain(**kwargs):
+    """ Reconstruct task chain form given task ID.
+
+    :param tid: task ID
+    :type tid: int, str
+
+    :return: task chain:
+             {
+                 ...,
+                 taskidN: [childN1_id, childN2_id, ...],
+                 ...
+             }
+    :rtype: dict
+    """
+    return es.task_chain(**kwargs)

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -10,7 +10,7 @@ import json
 from datetime import date
 
 from ..exceptions import DkbApiNotImplemented
-from exceptions import StorageClientException, QueryNotFound, MissedParameter
+from exceptions import StorageClientException, QueryNotFound, MissedParameter, NoDataFound
 from .. import config
 
 # To ensure storages are named same way in all messages
@@ -23,6 +23,7 @@ QUERY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 
 try:
     import elasticsearch
+    from elasticsearch.exceptions import NotFoundError
 except ImportError:
     logging.warn("Failed to import module 'elasticsearch'. All methods"
                  " communicating with %s will fail." % STORAGE_NAME)
@@ -170,3 +171,131 @@ def _raw_task_steps_hist(**kwargs):
     q['body'] = get_query('task-steps-hist', **kwargs)
     r = client().search(**q)
     return r
+
+
+def task_chain(**kwargs):
+    """ Reconstruct task chain from given task ID.
+
+    If task not found in the ES, raises ``NoDataFound``.
+
+    If for given task no ``chain_id`` found, task ID is used instead.
+
+    :param tid: task ID
+    :type tid: int, str
+
+    :return: task chain:
+             {
+                 ...,
+                 taskidN: [childN1_id, childN2_id, ...],
+                 ...
+             }
+    :rtype: dict
+    """
+    init()
+    tid = kwargs.get('tid')
+    task_data = _task_info(tid, fields=['chain_id'])
+    if not task_data:
+        raise NoDataFound(STORAGE_NAME, 'Task (taskid = %s)' % tid)
+    chain_id = task_data.get('chain_id', tid)
+    data = _chain_data(chain_id)
+    result = _construct_chain(data)
+    return result
+
+
+def _task_info(tid, fields=None):
+    """ Return information by Task ID.
+
+    :param tid: task ID
+    :type tid: int, str
+    :param fields: list of fields to be retrieved (``None`` for all fields)
+    :type fields: list, None
+
+    :return: retrieved fields (None if task with ``tid`` is not found)
+    :rtype: dict, NoneType
+    """
+    kwargs = dict(TASK_KWARGS)
+    kwargs['id'] = tid
+    if fields is not None:
+        kwargs['_source'] = fields
+    try:
+        r = client().get(**kwargs)
+    except NotFoundError, err:
+        kwargs.update({'storage': STORAGE_NAME})
+        logging.warn("Failed to get information from %(storage)s: id='%(id)s',"
+                     " index='%(index)s', doctype='%(doc_type)s'" % kwargs)
+        return None
+    return r.get('_source', {})
+
+
+def _chain_data(chain_id):
+    """ Get full set of chain data from the ES.
+
+    :param chain_id: chain ID ( = root task ID)
+    :type chain_id: int, str
+
+    :return: chain data -- lists of task IDs, ordered from root to every task
+             belonging to the chain:
+             [
+                 ...,
+                 [chain_id, other_taskid_1, other_taskid_2, ..., taskid],
+                 ...
+             ]
+    :rtype: list
+    """
+    kwargs = dict(TASK_KWARGS)
+    kwargs['body'] = {'query': {'term': {'chain_id': chain_id}}}
+    kwargs['_source'] = ['chain_data']
+    kwargs['from_'] = 0
+    kwargs['size'] = 2000
+    rtrn = []
+    while True:
+        results = client().search(**kwargs)
+        if not results['hits']['hits']:
+            break
+        for hit in results['hits']['hits']:
+            chain_data = hit['_source'].get('chain_data')
+            if chain_data:
+                rtrn.append(chain_data)
+        kwargs['from_'] += kwargs['size']
+    return rtrn
+
+
+def _construct_chain(chain_data):
+    """ Reconstruct chain structure from the chain_data.
+
+    Chain is a group of tasks where the first task is the root, and each next
+    task has one of the previous ones as its parent (parent's output includes
+    child's input).
+
+    :param chain_data: chain_data of all tasks in the chain (in the form
+                       corresponding outcome of ``_chain_data()``)
+    :type chain_data: list
+
+    :return: constructed chain -- hash with keys of task IDs and values of the
+             given task's child IDs:
+             {
+                 ...,
+                 taskidN: [childN1_id, childN2_id, ...],
+                 ...
+             }
+    :rtype: dict
+    """
+    chain = {}
+    # Order data from longest to shortest lists. Processing [1, 2, 3] is faster
+    # than processing [1], then [1, 2] and then [1, 2, 3].
+    # TODO: check this more extensively.
+    chain_data.sort(key=lambda cd: len(cd), reverse=True)
+    for cd in chain_data:
+        cd.reverse()
+        child = False
+        for tid in cd:
+            if tid in chain:
+                if child:
+                    chain[tid].append(child)
+                break
+            else:
+                chain[tid] = []
+                if child:
+                    chain[tid].append(child)
+                child = tid
+    return chain

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -10,7 +10,11 @@ import json
 from datetime import date
 
 from ..exceptions import DkbApiNotImplemented
-from exceptions import StorageClientException, QueryNotFound, MissedParameter, NoDataFound
+from exceptions import (StorageClientException,
+                        QueryNotFound,
+                        MissedParameter,
+                        NoDataFound
+                        )
 from .. import config
 
 # To ensure storages are named same way in all messages

--- a/Utils/API/server/lib/dkb/api/storages/exceptions.py
+++ b/Utils/API/server/lib/dkb/api/storages/exceptions.py
@@ -23,6 +23,17 @@ class StorageClientException(StorageException):
         super(StorageClientException, self).__init__(message)
 
 
+class NoDataFound(StorageException):
+    """ Exception indicating that requested data not found. """
+    code = 552
+
+    def __init__(self, storage, message=None):
+        reason = "No data found in %s" % storage
+        if message:
+            reason += ": %s" % message
+        self.details = reason
+
+
 class QueryException(StorageException):
     """ Exception indicating any failure in query prepatation. """
     code = 560


### PR DESCRIPTION
New API method (`/task/chain?tid=...`) is added.

The method returns chain info in the following format:
```
{
  ...,
  tidN: [childN_1, childN_2, ...],
  ...
}
```

To be used in chain-representing interfaces like [the one in BigPanDA](https://bigpanda.cern.ch/ganttTaskChain/?jeditaskid=7999893).