### PR TITLE
API: /task/chain method fix

### DIFF
--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -198,7 +198,7 @@ def task_chain(**kwargs):
     init()
     tid = kwargs.get('tid')
     task_data = _task_info(tid, fields=['chain_id'])
-    if not task_data:
+    if task_data is None:
         raise NoDataFound(STORAGE_NAME, 'Task (taskid = %s)' % tid)
     chain_id = task_data.get('chain_id', tid)
     data = _chain_data(chain_id)


### PR DESCRIPTION
If there is record for a given task, just no `chain_id`, we should not raise
`NoDataFound` -- it looks like there's no information for the task at all.