### PR TITLE
DF/09: add possibility to specify timestamps time zone (set to UTC).

### DIFF
--- a/Utils/Dataflow/config/009.cfg.example
+++ b/Utils/Dataflow/config/009.cfg.example
@@ -36,6 +36,9 @@ final = %__009_final_offset__%
 # offset from current timestamp (e.g. 86400 <=> 86400s <=> 1d; 8h; 15m)
 step = %__009_step__%
 
+# Time zone of timestamps (default: local timezone)
+tz = UTC
+
 [logging]
 # Current offset file
 # (relative to the dir with the config file or absolute path)


### PR DESCRIPTION
Previously 'naive' datetime objects were used, meaning in fact that we
treat `timestamp` field as timestamp in the local time zone. It has some
effect only when `now()` is used as a right limit of the integration
interval.

It is said (by M.Borodin) that `timestamp` is supposed to be in UTC, but
in fact it can be UTC or CET or CEST depending on when and who writes
the data.

Setting timestamp time zone to local time zone meant that records,
written with proper UTC, are likely to be missed (as we check every interval
one or two hours earlier then records are written).

Setting timestamp time zone to the UTC means that for records with
timestamp in CE(S)T we won't see changes as soon as they are written to
the Oracle DB; but they will be handled later. It is not best, but still
better than missing records. When things get standardized and all the
update operations start setting UTC timestamp, it will work just fine.