### PR TITLE
[obsolete] DF/data4es: 'update' mode for safe dataset metadata update.

### DIFF
--- a/Utils/Dataflow/pyDKB/storages/es.py
+++ b/Utils/Dataflow/pyDKB/storages/es.py
@@ -22,7 +22,8 @@ except ImportError:
 
 DEFAULT_CFG = {
     'host': '127.0.0.1',
-    'port': '9200'
+    'port': '9200',
+    'timeout_retry': 3
 }
 
 
@@ -50,11 +51,12 @@ class ES(Storage):
         """ Configure ES client.
 
         Configuration parameters:
-          host     (str: '127.0.0.1')
-          port     (str: '9200')
-          index    (str)
-          user     (str)
-          __passwd (str)
+          host          (str: '127.0.0.1')
+          port          (str: '9200')
+          index         (str)
+          user          (str)
+          __passwd      (str)
+          timeout_retry (int: 3)
 
         :param cfg: configuration parameters
         :type cfg: dict
@@ -67,6 +69,9 @@ class ES(Storage):
             kwargs['http_auth'] = '%(user)s:%(__passwd)s' % cfg
         if cfg.get('index'):
             self.index = cfg['index']
+        kwargs['retry_on_timeout'] = True
+        kwargs['max_retries'] = cfg.get('timeout_retry',
+                                        DEFAULT_CFG['timeout_retry'])
         self.c = elasticsearch.Elasticsearch(hosts, **kwargs)
 
     def get(self, id, fields=None, index=None, doc_type='_all', parent=None):

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -4,6 +4,7 @@ SCRIPT_NAME=data4es
 
 BATCH_SIZE=100
 DEBUG=
+UPDATE=
 
 base_dir=$( cd "$(dirname "$(readlink -f "$0")")"; pwd)
 
@@ -170,6 +171,8 @@ while [ -n "$1" ]; do
   case $1 in
     --debug)
       DEBUG=1;;
+    --update)
+      UPDATE=1;;
     --)
       shift
       break;;
@@ -181,6 +184,12 @@ while [ -n "$1" ]; do
   shift
 done
 
+if [ -n "$UPDATE" ]; then
+  es_cfg=`get_config "es"`
+  cmd_91_in="$cmd_91_in --es-config $es_cfg"
+  cmd_91_out="$cmd_91_out --es-config $es_cfg"
+  cmd_95="$cmd_95 --es-config $es_cfg"
+fi
 
 # Define subchains
 # Source subchain: Oracle Connector


### PR DESCRIPTION
Closed for #253 + #262 + #263 in sum do the trick: we can run `data4es` with `-i 91_in,91_out,95` and be sure that data that already present in ES won't be spoiled.

#320 is the next step in this direction that will allow getting data from Rucio but in case of error fall back to the "update" scenario.

However it does not provide functionality like "query Rucio only if we don't have these data in ES". It'd be nice, but in fact it should be done by introducing another stage that would extract all available information from ES in the beginning of the `data4es` process, instead of asking every stage to query ES for its own data.

Original description
---

Applies functionality added in #245 and #246 to the `data4es` process, allowing to start this process in a normal (basic integration) and 'safe' (archive update) mode, which can be turned on with `--update` option.

[WIP] is due to the pyDKB-related changes: they clearly do not belong here. By the way, even after this change I have seen that `ConnectionTimeout` exception; but as we are talking about 'archived metadata update', it seems to me quite OK to be interrupted in case of overloaded ES and restart after an hour or so.

---

Waits for #245, #246.