### PR TITLE
DF/009: improve `offset_now()` function.

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -312,7 +312,7 @@ def offset_now(tz=None):
     TZ = OFFSET_TZ
     if tz:
         TZ = pytz.timezone(tz)
-    return TZ.fromutc(datetime.utcnow()).replace(tzinfo=None)
+    return datetime.now(TZ).replace(tzinfo=None)
 
 
 def plain(conn, queries, start_date, end_date):


### PR DESCRIPTION
There was used not very readable way to get current datetime in specific
timezone; new way looks much simplier and gives same result.

Also, it helps in case of undefined `OFFSET_TZ`: if it is `None` and no
`tz` is passed to the function, we will end up with `None.fromutc(...)`,
which will result in `AttributeError`. In the new version same situation
leads simply to `datetime.now(None)`, which is interpreted as "No time
zone specified, so use local time zone." Looks reasonable enough.