### PR TITLE
DF/019: EOM handling improvement

### DIFF
--- a/Utils/Dataflow/019_esFormat/README
+++ b/Utils/Dataflow/019_esFormat/README
@@ -38,8 +38,8 @@ To produce regular (seamless NDJSON) samples, run:
 
 Comment:
  * input samples can not be used (and output one -- saved) as-is
-   due to the specific EOM marker (most of the stages use NEWLINE, which
-   is not allowed here because of the output message format);
+   due to the specific EOM marker (most of the stages use NEWLINE, which,
+   being part of the output messages body, is not allowed here);
  * `tr` is a Unix utility to translate or delete characters (for details please
    refer to man pages);
  * output message body contains trailing NEWLINE, so RS is simply removed from

--- a/Utils/Dataflow/019_esFormat/README
+++ b/Utils/Dataflow/019_esFormat/README
@@ -31,7 +31,21 @@ JSON documents, one document per line:
 
 Samples
 -------
-The 'output' directory contains two pairs of samples:
+To produce regular (seamless NDJSON) samples, run:
+
+  cat input/sample_name.ndjson | tr $'\n' $'\x1e' | \
+    ./run.sh -E '' | tr -d $'\x1e' > output/sample_name.ndjson
+
+Comment:
+ * input samples can not be used (and output one -- saved) as-is
+   due to the specific EOM marker (most of the stages use NEWLINE, which
+   is not allowed here because of the output message format);
+ * `tr` is a Unix utility to translate or delete characters (for details please
+   refer to man pages);
+ * output message body contains trailing NEWLINE, so RS is simply removed from
+   the output stream (not replaced with another NEWLINE).
+
+The 'output' directory contains two pairs of regular samples:
 
 2016 data:
 tasks2016.ndjson (from 016's 2016 sample)

--- a/Utils/Dataflow/019_esFormat/README
+++ b/Utils/Dataflow/019_esFormat/README
@@ -32,15 +32,6 @@ JSON documents, one document per line:
  ...
 }}}
 
-TODO
-----
-Currently, it operates as if one line was one message (piece of information).
-For input it is OK, but for output it would be better to take <index info> and
-  <data> JSON documents together, as one message. I don`t know where it will
-  be critical for now, but something tells me that it will.
-This task requires accurate EOMessage and EOProcess markers handling (see the
-  `kafka-dataflow-markers` branch).
-
 Samples
 -------
 The 'output' directory contains two pairs of samples:

--- a/Utils/Dataflow/019_esFormat/README
+++ b/Utils/Dataflow/019_esFormat/README
@@ -27,9 +27,6 @@ JSON documents, one document per line:
 {{{
  <index info>
  <data>
- <index info>
- <data>
- ...
 }}}
 
 Samples

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -8,7 +8,7 @@ set_error_handler("exception_error_handler");
 $DEFAULT_INDEX = 'tasks_production';
 $ES_INDEX = NULL;
 $EOP_DEFAULTS = Array("stream" => chr(0), "file" => "");
-$EOM_DEFAULTS = Array("stream" => "\n", "file" => "\n");
+$EOM_DEFAULTS = Array("stream" => chr(30), "file" => chr(30));
 
 function check_input($row) {
   $required_fields = array('_id', '_type');

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -133,7 +133,7 @@ if ($h) {
     $index = constructIndexJson($row);
 
     echo json_encode($index)."\n";
-    echo json_encode($row);
+    echo json_encode($row)."\n";
     echo $EOM_MARKER;
     echo $EOP_MARKER;
   }

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -120,7 +120,7 @@ if (!$ES_INDEX) {
 }
 
 if ($h) {
-  while (($line = fgets($h)) !== false) {
+  while (($line = stream_get_line($h, 0, $EOM_MARKER)) !== false) {
     $row = json_decode($line,true);
 
     if (!check_input($row)) {

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -109,6 +109,12 @@ if ($EOM_MARKER == '') {
   fwrite(STDERR, "(ERROR) EOM marker can not be empty string.\n");
   exit(1);
 }
+if ($EOM_MARKER == "\n") {
+  fwrite(STDERR, "(ERROR) NEWLINE symbol is not allowed as EOM, "
+                 ."as it is contained in output messages.\n");
+  exit(1);
+}
+
 
 fwrite(STDERR, "(DEBUG) End-of-message marker: '" . $EOM_MARKER . "' (hex: " . $EOM_HEX . ").\n");
 fwrite(STDERR, "(DEBUG) End-of-process marker: '" . $EOP_MARKER . "' (hex: " . $EOP_HEX . ").\n");

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -194,7 +194,7 @@ sink_chain() {
   [ -n "$DEBUG" ] \
     && cmd="tee 69.$1.inp" \
     || cmd=$cmd_69
-  $cmd_19 | eop_filter | mediator "$1" | $cmd > /dev/null
+  tr $'\n' $'\x1e' | $cmd_19 | tr -d $'\x1e' | eop_filter | mediator "$1" | $cmd > /dev/null
 }
 
 log "Starting process."


### PR DESCRIPTION
* fix input stream handling (no EOM was taken into account for the input stream);
* more strict output message definition (it must include last `\n` symbol as it is required by ES bulk API and must get there -- and if it is added as EOM, it will be removed on the next stage);
* new default EOM value (as `\n` appears in the message body, it can not be used as EOM);
* README updated accordingly.