### PR TITLE
Stage 009: delay

### DIFF
--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -325,7 +325,7 @@ def offset_now(tz=None, delay=None):
                time zone is used.
     :type tz: str, NoneType
     :param delay: delay in seconds. If not specified, default (globally set)
-               value is used.
+                  value is used.
     :type delay: int, NoneType
 
     :return: offset value (naive datetime, adjusted to OFFSET_TZ)

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -143,8 +143,9 @@ def read_config(config_file):
     delay = config_get(config, 'timestamps', 'delay', '0')
     result['delay'] = interval_seconds(delay)
     if result['delay'] < 0:
-        # Delay is only used when 'final_date' is 'now'. It does not make much
-        # sense to ask for data from the future.
+        # Delay is used when right border of the data taking interval is
+        # 'now'.
+        # It does not make much sense to ask for data from the future.
         sys.stderr.write('(WARN) Delay is less than 0, setting it to 0.\n')
         result['delay'] = 0
     if result['step_seconds'] > 0:

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -328,7 +328,8 @@ def offset_now(tz=None, delay=None):
                   value is used.
     :type delay: int, NoneType
 
-    :return: offset value (naive datetime, adjusted to OFFSET_TZ)
+    :return: offset value (naive datetime, adjusted to OFFSET_TZ with
+             OFFSET_DELAY)
     :rtype: datetime.datetime
     """
     TZ = OFFSET_TZ

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -25,7 +25,7 @@ OUT = os.fdopen(sys.stdout.fileno(), 'w', 0)
 # (used to adjust 'now' to the proper value)
 OFFSET_TZ = None
 # Delay
-# (used to adjust 'now' when performing consistency check)
+# (used to adjust 'now' to avoid pulling of "unstable" data)
 OFFSET_DELAY = None
 # ---
 

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -24,6 +24,9 @@ OUT = os.fdopen(sys.stdout.fileno(), 'w', 0)
 # Timezone of the data timestamps in the source DB
 # (used to adjust 'now' to the proper value)
 OFFSET_TZ = None
+# Delay
+# (used to adjust 'now' when performing consistency check)
+OFFSET_DELAY = None
 # ---
 
 
@@ -53,6 +56,8 @@ def main():
 
     # Offset timezone initialization
     init_offset_tz(config)
+    # Offset delay initialization
+    init_offset_delay(config)
 
     conn = OracleConnection(config['__dsn'])
     if not conn.establish():
@@ -135,11 +140,18 @@ def read_config(config_file):
     # Optional parameters
     result['timestamp_tz'] = config_get(config, 'timestamps', 'tz',
                                         time.tzname[0])
+    delay = config_get(config, 'timestamps', 'delay', '0')
+    result['delay'] = interval_seconds(delay)
+    if result['delay'] < 0:
+        # Delay is only used when 'final_date' is 'now'. It does not make much
+        # sense to ask for data from the future.
+        sys.stderr.write('(WARN) Delay is less than 0, setting it to 0.\n')
+        result['delay'] = 0
     if result['step_seconds'] > 0:
         default_initial = datetime.utcfromtimestamp(0)
         default_final = None
     else:
-        default_initial = offset_now(result['timestamp_tz'])
+        default_initial = offset_now(result['timestamp_tz'], result['delay'])
         default_final = datetime.utcfromtimestamp(0)
 
     result['final_date'] = str2date(config_get(config, 'timestamps', 'final',
@@ -226,6 +238,12 @@ def init_offset_tz(config):
     OFFSET_TZ = pytz.timezone(config['timestamp_tz'])
 
 
+def init_offset_delay(config):
+    """ Initialize OFFSET_DELAY. """
+    global OFFSET_DELAY
+    OFFSET_DELAY = config['delay']
+
+
 def init_offset_storage(config):
     """ Get configured (or default) offset file.
 
@@ -299,12 +317,15 @@ def get_offset(offset_storage):
     return result
 
 
-def offset_now(tz=None):
+def offset_now(tz=None, delay=None):
     """ Get offset value corresonding to the current moment of time.
 
     :param tz: time zone name. If not specified, default (globally set)
                time zone is used.
     :type tz: str, NoneType
+    :param delay: delay in seconds. If not specified, default (globally set)
+               value is used.
+    :type delay: int, NoneType
 
     :return: offset value (naive datetime, adjusted to OFFSET_TZ)
     :rtype: datetime.datetime
@@ -312,7 +333,10 @@ def offset_now(tz=None):
     TZ = OFFSET_TZ
     if tz:
         TZ = pytz.timezone(tz)
-    return datetime.now(TZ).replace(tzinfo=None)
+    dl = OFFSET_DELAY
+    if delay:
+        dl = delay
+    return datetime.now(TZ).replace(tzinfo=None) - timedelta(seconds=dl)
 
 
 def plain(conn, queries, start_date, end_date):

--- a/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
+++ b/Utils/Dataflow/009_oracleConnector/Oracle2JSON.py
@@ -559,7 +559,7 @@ def interval_seconds(step):
         raise ValueError("Failed to decode numeric part of the interval: %s"
                          % step)
     except KeyError:
-        raise ValueError("Failes to decode index of the interval: %s" % step)
+        raise ValueError("Failed to decode index of the interval: %s" % step)
 
 
 def str2date(str_date):

--- a/Utils/Dataflow/config/009.cfg.example
+++ b/Utils/Dataflow/config/009.cfg.example
@@ -35,6 +35,13 @@ initial = %__009_init_offset__%
 final = %__009_final_offset__%
 # offset from current timestamp (e.g. 86400 <=> 86400s <=> 1d; 8h; 15m)
 step = %__009_step__%
+# delay (e.g. 86400 <=> 86400s <=> 1d; 8h; 15m)
+# This parameter can be used to adjust 'now'.
+# For example, running the script at 10-05-2016 12:00:00 with
+# delay = 2h will set 'final' to 10-05-2016 10:00:00.
+# Has no effect if 'final' is set explicitly.
+# Cannot be negative.
+delay = %__009_delay__%
 
 # Time zone of timestamps (default: local timezone)
 tz = UTC

--- a/Utils/Dataflow/config/009.cfg.example
+++ b/Utils/Dataflow/config/009.cfg.example
@@ -39,7 +39,8 @@ step = %__009_step__%
 # This parameter can be used to adjust 'now'.
 # For example, running the script at 10-05-2016 12:00:00 with
 # delay = 2h will set 'final' to 10-05-2016 10:00:00.
-# Has no effect if 'final' is set explicitly.
+# Has no effect if the right border of the data taking interval is
+# set explicitly.
 # Cannot be negative.
 delay = %__009_delay__%
 


### PR DESCRIPTION
Add an option to get data in stage 009 with the final date set to relative 'N seconds/minutes/hours/... ago' - it is already possible, but only with N = 0. One of the goals of this change is to be able to have a delay between data loading and data consistency checking, to avoid discrepancies caused by constant updates of data in Oracle which are mirrored to ES only when another data loading is performed.