### PR TITLE
pyDKB: minor fix (docstring)

### DIFF
--- a/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
+++ b/Utils/Dataflow/pyDKB/dataflow/stage/AbstractStage.py
@@ -218,7 +218,7 @@ class AbstractStage(object):
         sys.exit(3)
 
     def read_config(self):
-        """ Reads stage custom config file.
+        """ Read stage custom config file.
 
         :return: (True|False)
         """


### PR DESCRIPTION
We tend to write docstrings as "Do X", not "Does X" (according to
PEP-257). This method's docstring was inconsistent with the rule, so
fixed now.