### PR TITLE
DF/019: "incomplete" messages handling (ES updates, pt.1.2).

### DIFF
--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -95,8 +95,8 @@ function constructDataJson($row) {
   if (isset($incompl)) {
 
     # "_update_required" field must be specified explicitly in two cases:
-    #  * message is incomplete (so that record in ES get properly marked);
-    #  * we perfom "update" operation (since we want to use 'doc_as_upsert' ES
+    #  * message is incomplete (so that record in ES gets properly marked);
+    #  * we perform "update" operation (since we want to use 'doc_as_upsert' ES
     #    option, if possible, using "insert_data" for both cases --
     #    insert-if-missed and existing document update -- and still get
     #    resulting document properly marked)

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -80,18 +80,46 @@ function constructActionJson($row) {
 function constructDataJson($row) {
   $data = $row;
 
+  if (isset($data['_incomplete'])) {
+    $incompl = $data['_incomplete'];
+  }
+
   foreach ($data as $key => $val) {
     if (strncmp($key, '_', 1) === 0)
       unset($data[$key]);
   }
 
   $act = getAction($row);
+  $insert_data = $data;
+  $update_data = $data;
+  if (isset($incompl)) {
+    # We *may* not specify "update_required" value on insert, if it is False,
+    # (for it is a default value), but to allow usage of 'doc_as_upsert'
+    # ES option, it can be specified explicitly. So in case of 'update' action
+    # it should always be so.
+    if ($incompl or $act == 'update') {
+      $insert_data['update_required'] = $incompl;
+    }
+    if (!$incompl) {
+      # We must specify explicitly that update is not required after this operation
+      # (just in case it was set to "true" previously).
+      $update_data['update_required'] = false;
+    }
+  }
 
   if ($act == 'update') {
+    # We can do "clean upsert" (when insert and update documents are the same)
+    # only when $incompl is NOT set to True:
+    $clean_upsert = !(isset($incompl) and $incompl);
     $data = Array(
-      'doc' => $data,
-      'doc_as_upsert' => true
+      'doc' => $update_data,
+      'doc_as_upsert' => $clean_upsert
     );
+    if (!$clean_upsert) {
+      $data['upsert'] = $insert_data;
+    }
+  } else {
+    $data = $insert_data;
   }
 
   return $data;

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -93,13 +93,17 @@ function constructDataJson($row) {
   $insert_data = $data;
   $update_data = $data;
   if (isset($incompl)) {
-    # We *may* not specify "_update_required" value on insert, if it is False,
-    # (for it is a default value), but to allow usage of 'doc_as_upsert'
-    # ES option, it can be specified explicitly. So in case of 'update' action
-    # it should always be so.
+
+    # "_update_required" field must be specified explicitly in two cases:
+    #  * message is incomplete (so that record in ES get properly marked);
+    #  * we perfom "update" operation (since we want to use 'doc_as_upsert' ES
+    #    option, if possible, using "insert_data" for both cases --
+    #    insert-if-missed and existing document update -- and still get
+    #    resulting document properly marked)
     if ($incompl or $act == 'update') {
       $insert_data['_update_required'] = $incompl;
     }
+
     if (!$incompl) {
       # We must specify explicitly that update is not required after this operation
       # (just in case it was set to "true" previously).

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -93,17 +93,17 @@ function constructDataJson($row) {
   $insert_data = $data;
   $update_data = $data;
   if (isset($incompl)) {
-    # We *may* not specify "update_required" value on insert, if it is False,
+    # We *may* not specify "_update_required" value on insert, if it is False,
     # (for it is a default value), but to allow usage of 'doc_as_upsert'
     # ES option, it can be specified explicitly. So in case of 'update' action
     # it should always be so.
     if ($incompl or $act == 'update') {
-      $insert_data['update_required'] = $incompl;
+      $insert_data['_update_required'] = $incompl;
     }
     if (!$incompl) {
       # We must specify explicitly that update is not required after this operation
       # (just in case it was set to "true" previously).
-      $update_data['update_required'] = false;
+      $update_data['_update_required'] = false;
     }
   }
 

--- a/Utils/Elasticsearch/mapping/README
+++ b/Utils/Elasticsearch/mapping/README
@@ -17,6 +17,6 @@ toths06_failed: 'wasted' CPU resources (see description for `toths06`).
 input_events: derived value based on primary_input_events, requested_events,
               n_files_per_job, n_events_per_job, n_files_to_be_used.
 
-update_required: service field to mark documents that contain incomplete
-                 information about object and thus must be updated sooner
-                 or later
+_update_required: service field to mark documents that contain incomplete
+                  information about object and thus must be updated sooner
+                  or later

--- a/Utils/Elasticsearch/mapping/README
+++ b/Utils/Elasticsearch/mapping/README
@@ -17,3 +17,6 @@ toths06_failed: 'wasted' CPU resources (see description for `toths06`).
 input_events: derived value based on primary_input_events, requested_events,
               n_files_per_job, n_events_per_job, n_files_to_be_used.
 
+update_required: service field to mark documents that contain incomplete
+                 information about object and thus must be updated sooner
+                 or later

--- a/Utils/Elasticsearch/mapping/README
+++ b/Utils/Elasticsearch/mapping/README
@@ -19,4 +19,4 @@ input_events: derived value based on primary_input_events, requested_events,
 
 _update_required: service field to mark documents that contain incomplete
                   information about object and thus must be updated sooner
-                  or later
+                  or later.

--- a/Utils/Elasticsearch/mapping/tasks.mapping
+++ b/Utils/Elasticsearch/mapping/tasks.mapping
@@ -237,6 +237,9 @@
         },
         "n_files_to_be_used": {
           "type": "integer"
+        },
+        "update_required": {
+          "type": "boolean"
         }
       }
     },
@@ -288,6 +291,9 @@
         "me_pdf": {
           "type": "keyword",
           "ignore_above": 256
+        },
+        "update_required": {
+          "type": "boolean"
         }
       }
     }

--- a/Utils/Elasticsearch/mapping/tasks.mapping
+++ b/Utils/Elasticsearch/mapping/tasks.mapping
@@ -238,7 +238,7 @@
         "n_files_to_be_used": {
           "type": "integer"
         },
-        "update_required": {
+        "_update_required": {
           "type": "boolean"
         }
       }
@@ -292,7 +292,7 @@
           "type": "keyword",
           "ignore_above": 256
         },
-        "update_required": {
+        "_update_required": {
           "type": "boolean"
         }
       }


### PR DESCRIPTION
Information about message (in)completeness is, basically, some service information for this stage.
Currently it was decided to simply keep in the ES some service field that will allow to mark "incomplete" documents; later we will use it to estimate, how many records are affected on a regular basis, and decide what to do: allow "update" operation when we know we don't have the full document, but still want new information in the storage, or something else.

So Stage 19 now turns `_incomplete` field of the input message to the `update_required` ES field, and tries not to do something stupid about it (e.g. not to mark all record as "incomplete" when all we wanted was to update information from one specific external source).

ES mapping is updated accordingly.

**Question**: shouldn\`t the ES service field also start with underscore, like `"_update_required"`? This field should not be used by any of the existing stages, so it won\`t be erroneously ignored as a *message* service field; and it is obviously not a "data field", so if we take some data from ES, we most likely will ignore it (unless we want to get all the records that require update). Not sure about this point.

Points to consider:
 - [x] the **question** above *(discussed at Thu meetings; ES seems to allow such naming for fields)*;
 - [ ] before we can use `_incomplete` as a signal to `update` action, all the stages must leave undefined fields empty (for the fields that must  survive in ES after update).

---

~(Waits for: #254.)~ *(merged)*