### PR TITLE
DF: update README

### DIFF
--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -141,15 +141,16 @@ There are three types of stages:
 1. Source stage - an initial stage in a dataflow pipeline that gets data
 from an external source (CDS, Rucio, AMI, etc.).
 
-2. Transform stage - these stages perform a set of operations for different
-cases on metadata and form output messages according to a particular pattern
-(e.g. select relevant metadata from a raw dataset, append metadata
-to a message, prepare messages for upload).
+2. Transform stage - a transitional stage that performs single logical
+operation on the metadata. Set (chain) of transform stages forms the whole
+transformation process for messages emitted by Source. Transformation
+operations may include: format change, derived values calculation,
+message extension with metadata from an additional source, etc.
 
 2.1. Pre-sink stage - the last transform stage in a dataflow pipeline that
 prepares metadata for upload via sink stage; it awares about messages
-formatting rules. All the preparations should be done by the pre-sink
-stage.
+formatting rules. All the preparations for upload should be done by
+the pre-sink stage.
 
 3. Sink stage - a stage that uploads data into the DKB storage
 (Virtuoso, ES, ...). Every single sink stage should be preceded by

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -156,7 +156,7 @@ the pre-sink stage.
 (Virtuoso, ES, ...). Every single sink stage should be preceded by
 a corresponding pre-sink stage that transforms data and forms ready-to-send
 messages with a specific structure. Sink stage only gets prepared messages
-and uploads it without any re-formatting. It does not care about messages
+and uploads them without any re-formatting. It does not care about messages
 content. If message does not follow the template, most likely it
 will be rejected by the storage load API.
 

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -106,14 +106,16 @@ messages to upload).
 
 2.1 Pre-sink stage - the last transform stage in a dataflow pipeline that
 prepares metadata to upload via sink stage; it awares about messages
-formatting. All the messages preparations should be done by a pre-sink stage.
+formatting rules. All the messages preparations should be done by a pre-sink
+stage.
 
-3. Sink stage - a stage that uploads data into the DKB storage (Virtuoso
-or ES). We consider that every single sink stage requires a particular
-pre-sink stage that transform data and form ready-to-send messages with a
-particular structure. Sink stage only gets prepared messages and upload it
-without any re-formatting. It does not care about messages content.
-If message does not follow the template, it will not be uploaded.
+3. Sink stage - a stage that uploads data into the DKB storage
+(Virtuoso, ES, ...). Every single sink stage should be preceded by
+a corresponding pre-sink stage that transforms data and forms ready-to-send
+messages with a specific structure. Sink stage only gets prepared messages
+and uploads it without any re-formatting. It does not care about messages
+content. If message does not follow the template, most likely it
+will be rejected by the storage load API.
 
 ==============
 * REFERENCES *

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -91,6 +91,30 @@ intended for making sure that information is consistent between ProdSys2 and
 ES. It gets a very basic set of metadata from ProdSys2, adds ES-related
 fields, and checks that it is present in ES rather than uploading it.
 
+================
+* Stages types *
+================
+There are three types of stages:
+
+1. Source stage - an initial stage in a dataflow pipeline that gets data
+from an external source (CDS, Rucio, AMI, etc.)
+
+2. Transform stage - a stage that makes a set of different operations
+with metadata forming messages according to a particular pattern (e.g. select
+relevant metadata from a raw dataset, append metadata to a message, prepare
+messages to upload).
+
+2.1 Pre-sink stage - the last transform stage in a dataflow pipeline that
+prepares metadata to upload via sink stage; it awares about messages
+formatting. All the messages preparations should be done by a pre-sink stage.
+
+3. Sink stage - a stage that uploads data into the DKB storage (Virtuoso
+or ES). We consider that every single sink stage requires a particular
+pre-sink stage that transform data and form ready-to-send messages with a
+particular structure. Sink stage only gets prepared messages and upload it
+without any re-formatting. It does not care about messages content.
+If message does not follow the template, it will not be uploaded.
+
 ==============
 * REFERENCES *
 ==============

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -148,7 +148,7 @@ operations may include: format change, derived values calculation,
 message extension with metadata from an additional source, etc.
 
 2.1. Pre-sink stage - the last transform stage in a dataflow pipeline that
-prepares metadata for upload via sink stage; it awares about messages
+prepares metadata for upload via sink stage; it is aware of messages'
 formatting rules. All the preparations for upload should be done by
 the pre-sink stage.
 

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -143,7 +143,7 @@ from an external source (CDS, Rucio, AMI, etc.).
 
 2. Transform stage - a transitional stage that performs single logical
 operation on the metadata. Set (chain) of transform stages forms the whole
-transformation process for messages produced by Source. Transformation
+transformation process for messages produced by a source stage. Transformation
 operations may include: format change, derived values calculation,
 message extension with metadata from an additional source, etc.
 

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -146,7 +146,7 @@ cases on metadata and form output messages according to a particular pattern
 (e.g. select relevant metadata from a raw dataset, append metadata
 to a message, prepare messages for upload).
 
-2.1 Pre-sink stage - the last transform stage in a dataflow pipeline that
+2.1. Pre-sink stage - the last transform stage in a dataflow pipeline that
 prepares metadata for upload via sink stage; it awares about messages
 formatting rules. All the preparations should be done by the pre-sink
 stage.

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -99,7 +99,7 @@ There are three types of stages:
 1. Source stage - an initial stage in a dataflow pipeline that gets data
 from an external source (CDS, Rucio, AMI, etc.).
 
-2. Transform stage - a stage that makes a set of different operations
+2. Transform stage - these stages make a set of operations for different cases
 with metadata forming messages according to a particular pattern (e.g. select
 relevant metadata from a raw dataset, append metadata to a message, prepare
 messages to upload).

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -97,7 +97,7 @@ fields, and checks that it is present in ES rather than uploading it.
 There are three types of stages:
 
 1. Source stage - an initial stage in a dataflow pipeline that gets data
-from an external source (CDS, Rucio, AMI, etc.)
+from an external source (CDS, Rucio, AMI, etc.).
 
 2. Transform stage - a stage that makes a set of different operations
 with metadata forming messages according to a particular pattern (e.g. select

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -105,8 +105,8 @@ relevant metadata from a raw dataset, append metadata to a message, prepare
 messages to upload).
 
 2.1 Pre-sink stage - the last transform stage in a dataflow pipeline that
-prepares metadata to upload via sink stage; it awares about messages
-formatting rules. All the messages preparations should be done by a pre-sink
+prepares metadata for upload via sink stage; it awares about messages
+formatting rules. All the preparations should be done by the pre-sink
 stage.
 
 3. Sink stage - a stage that uploads data into the DKB storage

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -92,7 +92,7 @@ ES. It gets a very basic set of metadata from ProdSys2, adds ES-related
 fields, and checks that it is present in ES rather than uploading it.
 
 ================
-* Stages types *
+* Stage types *
 ================
 There are three types of stages:
 

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -91,32 +91,6 @@ intended for making sure that information is consistent between ProdSys2 and
 ES. It gets a very basic set of metadata from ProdSys2, adds ES-related
 fields, and checks that it is present in ES rather than uploading it.
 
-================
-* Stage types *
-================
-There are three types of stages:
-
-1. Source stage - an initial stage in a dataflow pipeline that gets data
-from an external source (CDS, Rucio, AMI, etc.).
-
-2. Transform stage - these stages perform a set of operations for different
-cases on metadata and form output messages according to a particular pattern
-(e.g. select relevant metadata from a raw dataset, append metadata
-to a message, prepare messages for upload).
-
-2.1 Pre-sink stage - the last transform stage in a dataflow pipeline that
-prepares metadata for upload via sink stage; it awares about messages
-formatting rules. All the preparations should be done by the pre-sink
-stage.
-
-3. Sink stage - a stage that uploads data into the DKB storage
-(Virtuoso, ES, ...). Every single sink stage should be preceded by
-a corresponding pre-sink stage that transforms data and forms ready-to-send
-messages with a specific structure. Sink stage only gets prepared messages
-and uploads it without any re-formatting. It does not care about messages
-content. If message does not follow the template, most likely it
-will be rejected by the storage load API.
-
 ==============
 * REFERENCES *
 ==============
@@ -159,8 +133,34 @@ following requirements:
 
 [3] EOP, End-of-Process marker. Default value: '\0' (NULL)
 
+==================
+* 3. Stage types *
+==================
+There are three types of stages:
+
+1. Source stage - an initial stage in a dataflow pipeline that gets data
+from an external source (CDS, Rucio, AMI, etc.).
+
+2. Transform stage - these stages perform a set of operations for different
+cases on metadata and form output messages according to a particular pattern
+(e.g. select relevant metadata from a raw dataset, append metadata
+to a message, prepare messages for upload).
+
+2.1 Pre-sink stage - the last transform stage in a dataflow pipeline that
+prepares metadata for upload via sink stage; it awares about messages
+formatting rules. All the preparations should be done by the pre-sink
+stage.
+
+3. Sink stage - a stage that uploads data into the DKB storage
+(Virtuoso, ES, ...). Every single sink stage should be preceded by
+a corresponding pre-sink stage that transforms data and forms ready-to-send
+messages with a specific structure. Sink stage only gets prepared messages
+and uploads it without any re-formatting. It does not care about messages
+content. If message does not follow the template, most likely it
+will be rejected by the storage load API.
+
 =====================================
-* 3. External sources (data mining) *
+* 4. External sources (data mining) *
 =====================================
 There are two general cases of external data sources.
 1. Standard sources (like RDBMS) - here we can use standard connectors.

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -99,10 +99,10 @@ There are three types of stages:
 1. Source stage - an initial stage in a dataflow pipeline that gets data
 from an external source (CDS, Rucio, AMI, etc.).
 
-2. Transform stage - these stages make a set of operations for different cases
-with metadata forming messages according to a particular pattern (e.g. select
-relevant metadata from a raw dataset, append metadata to a message, prepare
-messages to upload).
+2. Transform stage - these stages perform a set of operations for different
+cases on metadata and form output messages according to a particular pattern
+(e.g. select relevant metadata from a raw dataset, append metadata
+to a message, prepare messages for upload).
 
 2.1 Pre-sink stage - the last transform stage in a dataflow pipeline that
 prepares metadata for upload via sink stage; it awares about messages

--- a/Utils/Dataflow/README
+++ b/Utils/Dataflow/README
@@ -143,7 +143,7 @@ from an external source (CDS, Rucio, AMI, etc.).
 
 2. Transform stage - a transitional stage that performs single logical
 operation on the metadata. Set (chain) of transform stages forms the whole
-transformation process for messages emitted by Source. Transformation
+transformation process for messages produced by Source. Transformation
 operations may include: format change, derived values calculation,
 message extension with metadata from an additional source, etc.
 


### PR DESCRIPTION
This update is about the description of stage types.
The main reason to add this block is a declaration what stage in a dataflow
pipeline is responsible for data preparation before uploading (sink or
transform stage).

We consider to leave sink stages pretty simple. All data preparation
work should be done by pre-sink stage -- the last one transform stage in
any data pipeline.