### PR TITLE
travis-readme (fix): fixed check that long lines was found

### DIFF
--- a/Tests/travis/README_long_lines.sh
+++ b/Tests/travis/README_long_lines.sh
@@ -16,7 +16,7 @@ while read f; do
     [ "$url" = "$trimmed_line" ] && continue
     echo "$line"
   done`
-  if [ $(echo "$r" | wc -l) -gt 0 ];then
+  if [ -n "$r" ];then
     echo "Very long line(s) in $f:"
     getLinesFromFile "$f" "$r"
     e=1


### PR DESCRIPTION
`echo "" | wc -l` returns 1. Real thing that this check do is checking
that something passes long lines filter.
We should check exactly this, not lines count or anything else.