### PR TITLE
DF/025: fix ES query (taskid -> jeditaskid).

### DIFF
--- a/Utils/Dataflow/025_chicagoES/stage.py
+++ b/Utils/Dataflow/025_chicagoES/stage.py
@@ -191,7 +191,7 @@ def agg_query(taskid, agg_names):
         "query": {
             "bool": {
                 "must": [
-                    {"term": {"taskid": taskid}},
+                    {"term": {"jeditaskid": taskid}},
                     {"terms": {"jobstatus": JOB_STATUSES}}
                 ]
             }


### PR DESCRIPTION
For some reason "taskid" and "jeditaskid" are not always the same: e.g.
there are plenty of jobs with taskid==2 and jeditaskid!=2.