### PR TITLE
Fix broken symlinks.

### DIFF
--- a/Utils/Dataflow/060_upload2virtuoso/input
+++ b/Utils/Dataflow/060_upload2virtuoso/input
@@ -1,1 +1,1 @@
-../053_datasets2TTL/output/
+../054_docContent2TTL/output/

--- a/Utils/Elasticsearch/tools/load_data.sh
+++ b/Utils/Elasticsearch/tools/load_data.sh
@@ -1,1 +1,1 @@
-Dataflow/069_upload2es/load_data.sh
+../../Dataflow/069_upload2es/load_data.sh


### PR DESCRIPTION
Stage 053 was removed long ago; an example of TTL files can be found in
output of stage 054.

ES-related tool (Utils/Elasticsearch/tools/load_data.sh) was turned into
stage 060, but somehow the link was set incorrectly.