### PR TITLE
API/setup: keep installation parameters

### DIFF
--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -78,6 +78,12 @@ OPTIONS
 
     -l, --listen HOST:PORT  address for Nginx to listen
                             Default: $ADDR
+
+  INSTALLATION PARAMETERS
+
+    --restore-defaults
+                     restore default configuration parameters
+                     (remove stored configuration) and exit
 "
 }
 
@@ -144,6 +150,10 @@ while [ $# -gt 0 ]; do
       MANAGE_NGINX=1
       MANAGE_SEL=1
       MANAGE_SERVICE=1
+      ;;
+    --restore-defaults)
+      [ -f "$cfg_file" ] && mv "$cfg_file"{,.old}
+      exit
       ;;
     --)
       break

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -84,6 +84,8 @@ OPTIONS
     --restore-defaults
                      restore default configuration parameters
                      (remove stored configuration) and exit
+
+    --show-cfg       show stored configuration and exit
 "
 }
 
@@ -153,6 +155,12 @@ while [ $# -gt 0 ]; do
       ;;
     --restore-defaults)
       [ -f "$cfg_file" ] && mv "$cfg_file"{,.old}
+      exit
+      ;;
+    --show-cfg)
+      [ -f "$cfg_file" ] \
+        && cat "$cfg_file" \
+        || echo "No stored configuration found ($cfg_file)." >&2
       exit
       ;;
     --)

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -99,7 +99,10 @@ load_cfg() {
 save_cfg() {
   vars=`set -o posix; set | grep ^[A-Z] | grep -v -e ^BASH -e ^FUNCNAME -e ^PIPESTATUS`
   new_cfg=`echo "$vars" | grep -v -f "$env_vars"`
-  echo "$new_cfg" > "$cfg_file"
+  echo "$new_cfg" > "$cfg_file.tmp"
+  # If config has changed -- save previous in .old file
+  [ -f "$cfg_file" ] && diff "$cfg_file"{,.tmp} &> /dev/null && mv "$cfg_file"{,.old}
+  mv "$cfg_file"{.tmp,}
 }
 
 [[ "$*" =~ "--help" ]] || load_cfg

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -85,6 +85,8 @@ OPTIONS
                      restore default configuration parameters
                      (remove stored configuration) and exit
 
+    --restore-cfg    restore previous configuration and exit
+
     --show-cfg       show stored configuration and exit
 "
 }
@@ -155,6 +157,14 @@ while [ $# -gt 0 ]; do
       ;;
     --restore-defaults)
       [ -f "$cfg_file" ] && mv "$cfg_file"{,.old}
+      exit
+      ;;
+    --restore-cfg)
+      [ -f "${cfg_file}.old" ] \
+        || { echo "No configuration file found to restore." >&2 && exit 1; }
+      [ -f "$cfg_file" ] && mv "$cfg_file"{,.tmp}
+      mv "$cfg_file"{.old,}
+      [ -f "${cfg_file}.tmp" ] && mv "$cfg_file"{.tmp,.old}
       exit
       ;;
     --show-cfg)


### PR DESCRIPTION
Now it will be enough to run `setup.sh` once with all configuration parameters required (`--dest`, etc). They will be stored in user home directory in file `~/.dkb-api` and reused on the next run (and still can be modified with cmdline parameters).

New command line parameters:
* `--restore-defaults` -- remove stored configuration;
* `--restore-cfg` -- restore previous configuration;
* `--show-cfg` -- show current configuration.