### PR TITLE
API/setup: add `conf/dkb.yaml` to setup files list.

### DIFF
--- a/Utils/API/server/.files
+++ b/Utils/API/server/.files
@@ -9,3 +9,5 @@ lib/dkb/api/storages/*.py
 lib/dkb/api/storages/es/
 lib/dkb/api/storages/es/query/
 lib/dkb/api/storages/es/query/*
+conf/
+conf/dkb.yaml

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -332,6 +332,7 @@ build_www() {
   cd "$base_dir"
   files=`cat .files`
   for f in $files; do
+    [ -e "$f" ] || continue
     if [ -d "$f" ]; then
       mkdir -p "$build_dir/$f"
     else
@@ -351,6 +352,7 @@ install_www() {
   files=`cat .files`
   echo "Installing www files..." >&2
   for f in $files; do
+    [ -e "$build_dir/$f" ] || continue
     echo "> $WWW_DIR/$f" >&2
     if [ -d "$build_dir/$f" ]; then
       mkdir -p "$WWW_DIR/$f"


### PR DESCRIPTION
If local `conf/dkb.yaml` exists, it will be copied to the WWW app
directory. It simplifies usage of `$WWW_DIR/conf` as `$CFG_DIR` (which
is a default value).