### PR TITLE
API/keywords: new API method for task search by keywords.

### DIFF
--- a/Utils/API/server/cgi-bin/dkb.fcgi
+++ b/Utils/API/server/cgi-bin/dkb.fcgi
@@ -43,7 +43,7 @@ def parse_params(qs):
        has value ``False``;
      * parameter with single value (``?key=val&...``) has value passed
        as ``val``;
-     * parameters with number of values (``?key[]=val1&key[]=val2&...``)
+     * parameters with number of values (``?key=val1&key=val2&...``)
        has value of type ``list``: ``['val1', 'val2', ..]``.
 
     :param qs: query string

--- a/Utils/API/server/cgi-bin/dkb.fcgi
+++ b/Utils/API/server/cgi-bin/dkb.fcgi
@@ -102,7 +102,12 @@ def construct_response(data, **kwargs):
             str_status = 'failed'
             body = 'error'
         result = {'status': str_status}
-        result[body] = data
+        for k in data.keys():
+            if k.startswith('_'):
+                item = data.pop(k)
+                result[k[1:]] = item
+        if body not in result:
+            result[body] = data
         if t0 and result.get('took_total') is None:
             result['took_total'] = int((time.time() - t0)*1000)
         indent = None

--- a/Utils/API/server/cgi-bin/dkb.fcgi
+++ b/Utils/API/server/cgi-bin/dkb.fcgi
@@ -103,9 +103,13 @@ def construct_response(data, **kwargs):
             body = 'error'
         result = {'status': str_status}
         for k in data.keys():
-            if k.startswith('_'):
-                item = data.pop(k)
-                result[k[1:]] = item
+            try:
+                if k.startswith('_'):
+                    item = data.pop(k)
+                    result[k[1:]] = item
+            except AttributeError:
+                # If key is not a string, we can simply skip
+                pass
         if body not in result:
             result[body] = data
         if t0 and result.get('took_total') is None:

--- a/Utils/API/server/cgi-bin/dkb.fcgi
+++ b/Utils/API/server/cgi-bin/dkb.fcgi
@@ -112,8 +112,8 @@ def construct_response(data, **kwargs):
                 pass
         if body not in result:
             result[body] = data
-        if t0 and result.get('took_total') is None:
-            result['took_total'] = int((time.time() - t0)*1000)
+        if t0 and result.get('took_total_ms') is None:
+            result['took_total_ms'] = int((time.time() - t0)*1000)
         indent = None
         newline = ''
         if kwargs.get('pretty'):

--- a/Utils/API/server/dkb.yaml.example
+++ b/Utils/API/server/dkb.yaml.example
@@ -4,4 +4,6 @@ storages:
       - 127.0.0.1:9200
     user: username
     passwd: supersecretpassword
-    index: index_name
+    index:
+      production_tasks: index_name_1
+      analysis_tasks: index_name_2

--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20191105'
+__version__ = '0.2.dev20191107'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -208,7 +208,7 @@ def task_kwsearch(path, **kwargs):
     :param kw: list of keywords (or a single keyword)
     :type kw: list, str
     :param analysis: if analysis tasks should be searched
-                     (default: False)
+                     (default: True)
     :type analysis: str, bool
     :param production: if production tasks should be searched
                        (default: True)
@@ -223,13 +223,21 @@ def task_kwsearch(path, **kwargs):
     """
     method_name = '/task/kwsearch'
     params = {
-        'analysis': False,
+        'analysis': True,
         'production': True,
         'size': 2000,
         'ds_size': 20,
         'timeout': 120
     }
     params.update(kwargs)
+    if (kwargs.get('analysis') is True):
+        params['production'] &= bool(kwargs.get('production'))
+    if (kwargs.get('production') is True):
+        params['analysis'] &= bool(kwargs.get('analysis'))
+    if not (params.get('analysis') or params.get('production')):
+        raise MethodException(method_name, "Parameters 'production' and "
+                              "'analysis' should not be set to False at the "
+                              "same time.")
     kw = kwargs.get('kw')
     if kw is None:
         raise MissedArgument(method_name, 'kw')

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -196,3 +196,52 @@ def task_chain(path, **kwargs):
 
 
 methods.add('/task', 'chain', task_chain)
+
+
+def task_kwsearch(path, **kwargs):
+    """ Get list of tasks by keywords.
+
+    Wildcard search is performed by ``taskname`` only.
+
+    :param path: full path to the method
+    :type path: str
+    :param kw: list of keywords (or a single keyword)
+    :type kw: list, str
+    :param analysis: if analysis tasks should be searched
+                     (default: False)
+    :type analysis: str, bool
+    :param production: if production tasks should be searched
+                       (default: True)
+    :type production: str, bool
+    :param size: number of task documents in response (default: 2000)
+    :type size: str, int
+    :param ds_size: max number of dataset documents returned for each task
+                    (default: 20)
+    :type size: str, int
+    :param timeout: request execution timeout (sec) (default: 120)
+    :type timeout: str, int
+    """
+    method_name = '/task/kwsearch'
+    params = {
+        'analysis': False,
+        'production': True,
+        'size': 2000,
+        'ds_size': 20,
+        'timeout': 120
+    }
+    params.update(kwargs)
+    kw = kwargs.get('kw')
+    if kw is None:
+        raise MissedArgument(method_name, 'kw')
+    if not isinstance(kw, list):
+        kw = [kw]
+    params['kw'] = kw
+    for p in ('size', 'ds_size', 'timeout'):
+        try:
+            params[p] = int(params[p])
+        except ValueError:
+            raise InvalidArgument(method_name, (p, params[p], int))
+    return storages.task_kwsearch(**params)
+
+
+methods.add('/task', 'kwsearch', task_kwsearch)

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -52,3 +52,28 @@ def task_chain(**kwargs):
     :rtype: dict
     """
     return es.task_chain(**kwargs)
+
+
+def task_kwsearch(**kwargs):
+    """ Search tasks and related datasets by keywords.
+
+    For wildcard keywords only ``taskname`` field is used.
+
+    :param kw: list of (string) keywords
+    :type kw: list
+    :param analysis: if analysis tasks should be searched
+    :type analysis: str, bool
+    :param production: if production tasks should be searched
+    :type production: str, bool
+    :param size: number of documents in response
+    :type size: str, int
+    :param ds_size: max number of datasets returned for each task
+    :type ds_size: str, int
+    :param timeout: request execution timeout (sec)
+    :type timeout: str, int
+
+    :return: task and related datasets info:
+             [ {..., output_dataset: [{...}, ...], ...}, ... ]
+    :rtype: list
+    """
+    return es.task_kwsearch(**kwargs)

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -78,6 +78,7 @@ def init():
         TASK_KWARGS['index'] = index['production_tasks']
     else:
         TASK_KWARGS['index'] = index
+        CONFIG['index']  = {'production_tasks': index}
     try:
         es = elasticsearch.Elasticsearch(hosts, http_auth=(user, passwd))
     except Exception, err:

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -369,7 +369,8 @@ def _task_kwsearch_query(kw, ds_size=100):
             "must": {
                 "query_string": {
                     "query": " AND ".join(qs_args),
-                    "analyze_wildcard": wildcard
+                    "analyze_wildcard": wildcard,
+                    "all_fields": True
                 }
             },
             "should": {

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -453,10 +453,9 @@ def task_kwsearch(**kwargs):
     q = _task_kwsearch_query(kwargs['kw'], kwargs['ds_size'])
     logging.debug("Keyword search query: %r" % q)
     idx = []
-    if kwargs['production']:
-        idx.append(CONFIG['index']['production_tasks'])
-    if kwargs['analysis']:
-        idx.append(CONFIG['index']['analysis_tasks'])
+    for name in ('production', 'analysis'):
+        if kwargs[name]:
+            idx.append(CONFIG['index'][name + '_tasks'])
     r = client().search(index=idx, body={"query": q}, size=kwargs['size'],
                         request_timeout=kwargs['timeout'])
     result = {'_took_storage': r['took'], '_data': []}

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -337,3 +337,133 @@ def _construct_chain(chain_data):
                     chain[tid].append(child)
                 child = tid
     return chain
+
+
+def _task_kwsearch_query(kw, ds_size=100):
+    """ Construct query for task keywords search.
+
+    :param kw: list of (string) keywords
+    :type kw: list
+    :param ds_size: number of output datasets to return
+                    (default: 100)
+    :type ds_size: int
+
+    :return: constructed query
+    :rtype: dict
+    """
+    qs_args = []
+    wildcard = False
+    for w in kw:
+        if '?' in w or '*' in w:
+            tokens = _get_tokens(w, analyzer='dsname_fields_wildcarded')
+            for t in tokens:
+                if '?' in w or '*' in w:
+                    qs_args.append('taskname.fields:%s' % w)
+                    wildcard = True
+                else:
+                    qs_args.append(w)
+        else:
+            qs_args.append(w)
+    q = {
+        "bool": {
+            "must": {
+                "query_string": {
+                    "query": " AND ".join(qs_args),
+                    "analyze_wildcard": wildcard
+                }
+            },
+            "should": {
+                "has_child": {
+                    "type": "output_dataset",
+                    "score_mode": "sum",
+                    "query": {"match_all": {}},
+                    "inner_hits": {"size": ds_size}
+                }
+            }
+        }
+    }
+    return q
+
+
+def _get_tokens(text, index='', field=None, analyzer=None):
+    """ Split text into tokens according to task/ds name fields.
+
+    :param text: text to split into tokens
+    :type text: str
+    :param index: ES index name (required for `field` usage)
+                  If not specified, configured default index is used;
+                  to ignore any index settings, should be set to ``None``
+    :type index: str
+    :param field: field name to derive analyzer (`index` is required)
+    :type field: str
+    :param analyzer: analyzer name or definition (if analyzer is defined
+                     for an index (not globally), `index` is required)
+    :type analyzer: str, dict
+
+    :return: list of tokens
+    :trype: list
+    """
+    if index is '':
+        index = TASK_KWARGS['index']
+    body = {"text": text}
+    result = []
+    if field:
+        if not index:
+            logging.warn("Index is not specified (will fail to tokenize string"
+                         " as field).")
+        body['field'] = field
+    elif analyzer:
+        body['analyzer'] = analyzer
+    try:
+        res = client().indices.analyze(index=index, body=body)
+        for r in res['tokens']:
+            result.append(r['token'])
+    except Exception, err:
+        logging.error("Failed to tokenize string: %r (index: %r). Reason: %s"
+                      % (body, index, err))
+        result = [text]
+    return result
+
+
+def task_kwsearch(**kwargs):
+    """ Implementation of ``task_kwsearch`` for ES.
+
+    :param kw: list of (string) keywords
+    :type kw: list
+    :param analysis: if analysis tasks should be searched
+    :type analysis: str, bool
+    :param production: if production tasks should be searched
+    :type production: str, bool
+    :param size: number of documents in response
+    :type size: int
+    :param ds_size: max number of output datasets to return for each task
+    :type ds_size: int
+    :param timeout: request execution timeout (sec)
+    :type timeout: int
+
+    :return: tasks and related datasets metadata:
+             [ ..., {..., output_dataset: [ {...}, ...], ... }, ... ]
+    :rtype: list
+    """
+    init()
+    q = _task_kwsearch_query(kwargs['kw'], kwargs['ds_size'])
+    logging.debug("Keyword search query: %r" % q)
+    idx = []
+    if kwargs['production']:
+        idx.append(CONFIG['index']['production_tasks'])
+    if kwargs['analysis']:
+        idx.append(CONFIG['index']['analysis_tasks'])
+    r = client().search(index=idx, body={"query": q}, size=kwargs['size'],
+                        request_timeout=kwargs['timeout'])
+    result = []
+    if not r['hits']['hits']:
+        return result
+    for hit in r['hits']['hits']:
+        task = hit['_source']
+        try:
+            datasets = hit['inner_hits']['output_dataset']['hits']['hits']
+        except KeyError:
+            datasets = []
+        task['output_dataset'] = [ ds['_source'] for ds in datasets ]
+        result.append(task)
+    return result

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -456,8 +456,14 @@ def task_kwsearch(**kwargs):
     idx = []
     try:
         for name in ('production', 'analysis'):
+            idx_name = CONFIG['index'][name + '_tasks']
             if kwargs[name]:
-                idx.append(CONFIG['index'][name + '_tasks'])
+                if idx_name:
+                    idx.append(idx_name)
+                else:
+                    msg = "Index name not configured (%s_tasks)." % name
+                    warn.append(msg)
+                    logging.warn(msg)
     except KeyError, err:
         msg = "Missed parameter in server configuration: %s" % str(err)
         warn.append(msg)

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -72,7 +72,12 @@ def init():
     hosts = CONFIG.get('hosts', None)
     user = CONFIG.get('user', '')
     passwd = CONFIG.get('passwd', '')
-    TASK_KWARGS['index'] = CONFIG.get('index', None)
+    index = CONFIG.get('index', None)
+    # Setting default index name
+    if isinstance(index, dict):
+        TASK_KWARGS['index'] = index['production_tasks']
+    else:
+        TASK_KWARGS['index'] = index
     try:
         es = elasticsearch.Elasticsearch(hosts, http_auth=(user, passwd))
     except Exception, err:

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -78,7 +78,7 @@ def init():
         TASK_KWARGS['index'] = index['production_tasks']
     else:
         TASK_KWARGS['index'] = index
-        CONFIG['index']  = {'production_tasks': index}
+        CONFIG['index'] = {'production_tasks': index}
     try:
         es = elasticsearch.Elasticsearch(hosts, http_auth=(user, passwd))
     except Exception, err:
@@ -483,6 +483,6 @@ def task_kwsearch(**kwargs):
             datasets = hit['inner_hits']['output_dataset']['hits']['hits']
         except KeyError:
             datasets = []
-        task['output_dataset'] = [ ds['_source'] for ds in datasets ]
+        task['output_dataset'] = [ds['_source'] for ds in datasets]
         result['_data'].append(task)
     return result

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -444,7 +444,7 @@ def task_kwsearch(**kwargs):
     :type timeout: int
 
     :return: tasks and related datasets metadata with additional info:
-             { _took_storage: <storage query execution time in ms>,
+             { _took_storage_ms: <storage query execution time in ms>,
                _total: <total number of matching tasks>,
                _data: [ ..., {..., output_dataset: [ {...}, ...], ... }, ... ]
              }
@@ -471,7 +471,7 @@ def task_kwsearch(**kwargs):
         logging.warn(msg)
     r = client().search(index=idx, body={"query": q}, size=kwargs['size'],
                         request_timeout=kwargs['timeout'])
-    result = {'_took_storage': r['took'], '_data': []}
+    result = {'_took_storage_ms': r['took'], '_data': []}
     if warn:
         result['_errors'] = warn
     if not r['hits']['hits']:

--- a/Utils/Elasticsearch/mapping/tasks.mapping
+++ b/Utils/Elasticsearch/mapping/tasks.mapping
@@ -4,10 +4,42 @@
     "number_of_shards": 4,
     "analysis": {
       "analyzer": {
-        "task_dataset_analyzer": {
+        "dsname": {
+          "char_filter": ["dsname_wildcarded", "remove_wildcard"],
+          "tokenizer": "dsname_tokenizer",
+          "filter": ["lowercase"]
+        },
+        "dsname_fields": {
+          "char_filter": ["dsname_wildcarded", "remove_wildcard"],
+          "tokenizer": "dsname_field_tokenizer",
+          "filter": "lowercase"
+        },
+        "dsname_fields_wildcarded": {
+          "char_filter": ["dsname_wildcarded"],
+          "tokenizer": "dsname_field_tokenizer",
+          "filter": "lowercase"
+        }
+      },
+      "tokenizer": {
+        "dsname_tokenizer": {
           "type": "pattern",
-          "pattern": "\\W|_",
-          "lowercase": true
+          "pattern": "\\.+|_+"
+        },
+        "dsname_field_tokenizer": {
+          "type": "pattern",
+          "pattern": "\\.+"
+        }
+      },
+      "char_filter": {
+        "dsname_wildcarded": {
+          "type": "pattern_replace",
+          "pattern": "[^a-zA-Z0-9_/.*?-]",
+          "replacement": ""
+        },
+        "remove_wildcard": {
+          "type": "pattern_replace",
+          "pattern": "[?*]",
+          "replacement": ""
         }
       }
     }
@@ -91,13 +123,17 @@
           "index": false,
           "doc_values": false
         },
-        "taskname": {
-          "type": "text",
-          "analyzer": "task_dataset_analyzer",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
+        "taskname" : {
+          "type" : "text",
+          "analyzer": "dsname",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword",
+              "ignore_above" : 256
+            },
+            "fields": {
+              "type": "text",
+              "analyzer": "dsname_fields"
             }
           }
         },
@@ -195,13 +231,17 @@
           "type": "keyword",
           "ignore_above": 256
         },
-        "primary_input": {
-          "type": "text",
-          "analyzer": "task_dataset_analyzer",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
+        "primary_input" : {
+          "type" : "text",
+          "analyzer": "dsname",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword",
+              "ignore_above" : 256
+            },
+            "fields": {
+              "type": "text",
+              "analyzer": "dsname_fields"
             }
           }
         },
@@ -245,13 +285,17 @@
         "type": "task"
       },
       "properties": {
-        "datasetname": {
-          "type": "text",
-          "analyzer": "task_dataset_analyzer",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
+        "datasetname" : {
+          "type" : "text",
+          "analyzer": "dsname",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword",
+              "ignore_above" : 256
+            },
+            "fields": {
+              "type": "text",
+              "analyzer": "dsname_fields"
             }
           }
         },


### PR DESCRIPTION
Method is available as `/task/kwsearch?kw=...`

Parameters:
* kw: single keyword (list of kwords is accepted as '?kw=...&kw=...')
* analysis: if analysis tasks should be searched (default: True)
* production: if production tasks should be searched (default: True)
* size: number of task documents in response (default: 2000)
* ds_size: max number of dataset documents returned for each task
           (default: 20)
* timeout: request execution timeout (sec) (default: 120)