### PR TITLE
API server setup improve

### DIFF
--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -71,6 +71,10 @@ OPTIONS
                      directory for (application) log files
                      Default: $LOG_DIR
 
+    -r, --run-dir DIR
+                     directory for .pid file
+                     Default: $RUN_DIR
+
     -s, --sock       socket name for communication between web-server
                      and API application
                      Default: $SOCK
@@ -131,6 +135,10 @@ while [ $# -gt 0 ]; do
       ;;
     -l|--log-dir)
       LOG_DIR=`readlink -m "$2"`
+      shift
+      ;;
+    -r|--run-dir)
+      RUN_DIR=`readlink -m "$2"`
       shift
       ;;
     -s|--sock)

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -62,7 +62,7 @@ OPTIONS
                      destination directory for installation
                      Default: $WWW_DIR
 
-    -c, --cfg-dir DIR
+    -C, --cfg-dir DIR
                      path to directory with configuration files used
                      by the application (absolute or relative to WWW_DIR)
                      Default: WWW_DIR/$CFG_DIR
@@ -71,7 +71,7 @@ OPTIONS
                      directory for (application) log files
                      Default: $LOG_DIR
 
-    -r, --run-dir DIR
+    -R, --run-dir DIR
                      directory for .pid file
                      Default: $RUN_DIR
 
@@ -83,7 +83,7 @@ OPTIONS
                      Default: $APP_USER
 
   WEB-SERVER
-    --nginx-dir DIR         Nginx home directory
+    -N, --nginx-dir DIR     Nginx home directory
                             Default: $NGINX_DIR
 
     -l, --listen HOST:PORT  address for Nginx to listen
@@ -127,7 +127,7 @@ while [ $# -gt 0 ]; do
       WWW_DIR=`readlink -m "$2"`
       shift
       ;;
-    -c|--cfg-dir)
+    -C|--cfg-dir)
       [[ "$2" == /* || "$2" == .* ]] \
         && CFG_DIR=`readlink -m "$2"` \
         || CFG_DIR="$2"
@@ -137,7 +137,7 @@ while [ $# -gt 0 ]; do
       LOG_DIR=`readlink -m "$2"`
       shift
       ;;
-    -r|--run-dir)
+    -R|--run-dir)
       RUN_DIR=`readlink -m "$2"`
       shift
       ;;
@@ -158,7 +158,7 @@ while [ $# -gt 0 ]; do
     -n|--nginx)
       MANAGE_NGINX=1
       ;;
-    --nginx-dir)
+    -N|--nginx-dir)
       NGINX_DIR=`readlink -m "$2"`
       shift
       ;;

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -67,6 +67,10 @@ OPTIONS
                      by the application (absolute or relative to WWW_DIR)
                      Default: WWW_DIR/$CFG_DIR
 
+    -l, --log-dir DIR
+                     directory for (application) log files
+                     Default: $LOG_DIR
+
     -s, --sock       socket name for communication between web-server
                      and API application
                      Default: $SOCK
@@ -123,6 +127,10 @@ while [ $# -gt 0 ]; do
       [[ "$2" == /* || "$2" == .* ]] \
         && CFG_DIR=`readlink -m "$2"` \
         || CFG_DIR="$2"
+      shift
+      ;;
+    -l|--log-dir)
+      LOG_DIR=`readlink -m "$2"`
       shift
       ;;
     -s|--sock)

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -67,7 +67,7 @@ OPTIONS
                      by the application (absolute or relative to WWW_DIR)
                      Default: WWW_DIR/$CFG_DIR
 
-    -l, --log-dir DIR
+    -L, --log-dir DIR
                      directory for (application) log files
                      Default: $LOG_DIR
 
@@ -133,7 +133,7 @@ while [ $# -gt 0 ]; do
         || CFG_DIR="$2"
       shift
       ;;
-    -l|--log-dir)
+    -L|--log-dir)
       LOG_DIR=`readlink -m "$2"`
       shift
       ;;


### PR DESCRIPTION
1. Added options:
    ```
    -L, --log-dir DIR       directory for (application) log files

    -R, --run-dir DIR       directory for .pid file
    ```
1. Short versions of directory-related options capitalized:
    ```
    -C, --cfg-dir DIR       path to directory with configuration files used
                            by the application (absolute or relative to WWW_DIR)

    -N, --nginx-dir DIR     Nginx home directory
    ```