### PR TITLE
API/kwsearch: fix issue with incorrect results for kw like "mc16_13tev".

### DIFF
--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -371,7 +371,8 @@ def _task_kwsearch_query(kw, ds_size=100):
                 "query_string": {
                     "query": " AND ".join(qs_args),
                     "analyze_wildcard": wildcard,
-                    "all_fields": True
+                    "all_fields": True,
+                    "default_operator": "AND"
                 }
             },
             "should": {


### PR DESCRIPTION
When `"all_fields": true` is used in `query_string` query, it analyzes
the string according to each field's analyzer (that's what we did it
for: to make sure that smth like "A14NNPDF23LO" from
"mc16_13TeV.303202.MadGraphPythia8EvtGen_A14NNPDF23LO_FRVZ_4LJ_mH800..."
can be used as a keyword). However when query string is "mc16_13tev",
for `taskname` field it is splitted into two tokens: "mc16" and "13tev".
And default operator is..."OR". So if "13tev" matches, ES won't care if
there's nothing about "mc16". Which is absolutely not what we're looking
for.

So -- the default operator is changed to "AND".