### PR TITLE
API: setup fix

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20191127'
+__version__ = '0.2.dev20191203'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -246,7 +246,7 @@ ensure_dirs() {
     mkdir -p "$dir" &>/dev/null
     chown "$APP_USER" "$dir"
     chmod 2750 "$dir"
-    [ "$dir" == "$SOCK_DIR" ] \
+    [ "$dir" -ef "$SOCK_DIR" ] \
       && chmod a+rwx "$dir" \
       && chown ":$NGINX_GROUP" "$dir"
   done

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -28,7 +28,8 @@ base_dir=$(readlink -f $(cd $(dirname "$0"); pwd))
 build_dir="${base_dir}/build"
 cfg_file=~/.dkb-api
 
-python_exec="LD_LIBRARY_PATH=$LD_LIBRARY_PATH `which python2.7`"
+python_exec="LD_LIBRARY_PATH=$LD_LIBRARY_PATH `which python2.7 2>/dev/null`" \
+  || { echo "ERROR: Python 2.7 required." >&2; exit 1; }
 
 usage() {
   echo "

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -28,6 +28,8 @@ base_dir=$(readlink -f $(cd $(dirname "$0"); pwd))
 build_dir="${base_dir}/build"
 cfg_file=~/.dkb-api
 
+python_exec="LD_LIBRARY_PATH=$LD_LIBRARY_PATH `which python2.7`"
+
 usage() {
   echo "
 USAGE
@@ -389,9 +391,9 @@ install_www() {
   done
   cmd_pref=""
   [ "`whoami`" == "$APP_USER" ] || cmd_pref="sudo -u $APP_USER"
-  $cmd_pref python -m compileall "$WWW_DIR/lib"
+  $cmd_pref $python_exec -m compileall "$WWW_DIR/lib"
   echo "Compiling $WWW_DIR/cgi-bin/dkb.fcgi ..." >&2
-  $cmd_pref python -m py_compile "$WWW_DIR/cgi-bin/dkb.fcgi"
+  $cmd_pref $python_exec -m py_compile "$WWW_DIR/cgi-bin/dkb.fcgi"
   echo "...done." >&2
   cd "$old_dir"
 }

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 env_vars=.env
-( set -o posix; set | cut -f 1 -d '=' | grep ^[A-Za-z_] ) > $env_vars
+( set -o posix; set | cut -f 1 -d '=' | grep ^[A-Za-z_] | sed 's/^\(.*\)$/^\1=/' ) > $env_vars
 
 # Change with caution, for this directory must have
 # specific permissions that allow nginx user

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -243,7 +243,7 @@ ensure_dirs() {
     echo "Creating dir: $dir" >&2
     [ -d "$dir" ] && continue
     mkdir -p "$dir" &>/dev/null
-    chown "$APP_USER:$NGINX_GROUP" "$dir"
+    chown "$APP_USER" "$dir"
     chmod 2750 "$dir"
     [ "$dir" == "$SOCK_DIR" ] && chmod a+rwx "$dir"
   done
@@ -379,7 +379,7 @@ install_www() {
     echo "> $WWW_DIR/$f" >&2
     if [ -d "$build_dir/$f" ]; then
       mkdir -p "$WWW_DIR/$f"
-      chown "$APP_USER:$NGINX_GROUP" "$WWW_DIR/$f"
+      chown "$APP_USER" "$WWW_DIR/$f"
       chmod 0744 "$WWW_DIR/$f"
     else
       cp "$build_dir/$f" -T "$WWW_DIR/$f"

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 env_vars=.env
-( set -o posix; set; ) > $env_vars
+( set -o posix; set | cut -f 1 -d '=' | grep ^[A-Za-z_] ) > $env_vars
 
 # Change with caution, for this directory must have
 # specific permissions that allow nginx user

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -246,7 +246,9 @@ ensure_dirs() {
     mkdir -p "$dir" &>/dev/null
     chown "$APP_USER" "$dir"
     chmod 2750 "$dir"
-    [ "$dir" == "$SOCK_DIR" ] && chmod a+rwx "$dir"
+    [ "$dir" == "$SOCK_DIR" ] \
+      && chmod a+rwx "$dir" \
+      && chown ":$NGINX_GROUP" "$dir"
   done
 }
 

--- a/Utils/API/server/setup.sh
+++ b/Utils/API/server/setup.sh
@@ -28,7 +28,7 @@ base_dir=$(readlink -f $(cd $(dirname "$0"); pwd))
 build_dir="${base_dir}/build"
 cfg_file=~/.dkb-api
 
-python_exec="LD_LIBRARY_PATH=$LD_LIBRARY_PATH `which python2.7 2>/dev/null`" \
+python_exec="`which python2.7 2>/dev/null`" \
   || { echo "ERROR: Python 2.7 required." >&2; exit 1; }
 
 usage() {
@@ -390,11 +390,11 @@ install_www() {
     fi
     chown "$APP_USER" "$WWW_DIR/$f"
   done
-  cmd_pref=""
+  cmd_pref=
   [ "`whoami`" == "$APP_USER" ] || cmd_pref="sudo -u $APP_USER"
-  $cmd_pref $python_exec -m compileall "$WWW_DIR/lib"
+  $cmd_pref env LD_LIBRARY_PATH="$LD_LIBRARY_PATH" $python_exec -m compileall "$WWW_DIR/lib"
   echo "Compiling $WWW_DIR/cgi-bin/dkb.fcgi ..." >&2
-  $cmd_pref $python_exec -m py_compile "$WWW_DIR/cgi-bin/dkb.fcgi"
+  $cmd_pref env LD_LIBRARY_PATH="$LD_LIBRARY_PATH" $python_exec -m py_compile "$WWW_DIR/cgi-bin/dkb.fcgi"
   echo "...done." >&2
   cd "$old_dir"
 }


### PR DESCRIPTION
Fixes:
* missed `APP_USER=<username>` in saved configuration;
* numerous error messages with `chown $APP_USER:$NGINX_GROUP`;
* wrong group ownership and permissions of `$SOCK_DIR` in some cases;
* Python versions conformity.

Changes:
* Python 2.7 is required now.

---

_Tested on aiatlas172_