### PR TITLE
DF/025: fix ES queries (doc_type changed).

### DIFF
--- a/Utils/Dataflow/025_chicagoES/stage.py
+++ b/Utils/Dataflow/025_chicagoES/stage.py
@@ -268,7 +268,6 @@ def agg_metadata(task_data, agg_names, retry=3, es_args=None):
             end = datetime.datetime.strptime(end_time, dt_format)
         es_args = {
             'index': get_indices_by_interval(beg, end, wildcard=True),
-            'doc_type': 'jobs_data',
             'body': agg_query(taskid, agg_names),
             'size': 0,
             'request_timeout': 30

--- a/Utils/Dataflow/025_chicagoES/stage.py
+++ b/Utils/Dataflow/025_chicagoES/stage.py
@@ -112,7 +112,6 @@ def task_metadata(taskid, fields=[], retry=3):
         return {}
     kwargs = {
         'index': 'tasks_archive_*',
-        'doc_type': 'task_data',
         'body': '{ "query": { "term": {"_id": "%s"} } }' % taskid,
         '_source': fields
     }


### PR DESCRIPTION
At some point doc_type in the UC ES indices `jobs_archive_*` has changed, and now it is "_doc" (the default one, like "no specific type").
Same seem to come for the `tasks_archive_*` at some point.

There's no documents with `toths06_failed` field (based on the jobs data) in the DKB ES after `03-02-20 12:31:40`; and in UC ES for now there's available only jobs since `2019-11-13T00:00:01.000Z` (at least via Search API).

After this fix we should re-integrate missed data, but should be careful not to remove what we can't recover.