### PR TITLE
DF/069: make data load more silent.

### DIFF
--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -47,7 +47,7 @@ SLEEP=5
 DELIMITER=`echo -e -n "\x00"`
 EOProcess=`echo -e -n "\x06"`
 
-cmd="curl $ES_AUTH http://$ES_HOST:$ES_PORT/_bulk?pretty --data-binary @"
+cmd="curl -sS $ES_AUTH http://$ES_HOST:$ES_PORT/_bulk?pretty --data-binary @"
 
 load_files () {
   [ -z "$1" -o ! -f "$1" ] && log $(usage) && exit 1


### PR DESCRIPTION
`curl -sS` == `curl --silent --show-error`

These options will prevent cURL from showing progress, yet allow error
messages in case of failure.