### PR TITLE
DF/025: allow CPU usage calculation for all tasks.

### DIFF
--- a/Utils/Dataflow/025_chicagoES/stage.py
+++ b/Utils/Dataflow/025_chicagoES/stage.py
@@ -65,9 +65,6 @@ META_FIELDS = {
 AGG_FIELDS = {'hs06sec_sum': 'toths06'}
 JOB_STATUSES = ['finished', 'failed']
 
-TASK_FINAL_STATES = ['done', 'finished', 'obsolete', 'failed', 'broken',
-                     'aborted']
-
 
 def init_es_client():
     """ Initialize connection to Chicago ES. """
@@ -254,9 +251,6 @@ def agg_metadata(task_data, agg_names, retry=3, es_args=None):
         sys.stderr.write("(ERROR) Connection to Chicago ES is not"
                          " established.")
         return None
-
-    if status not in TASK_FINAL_STATES:
-        return {}
 
     if not es_args:
         dt_format = '%d-%m-%Y %H:%M:%S'


### PR DESCRIPTION
Previously it was done only for the finished ones -- it was the part
of the task description provided by M.Borodin (since originally it was
supposed that we take this information from BigPanDA that would not be
happy if we queried it every now and again).

Now we're gonna get this information for all tasks: whatever's its
state, if there are some jobs -- we can get some useful data.