### PR TITLE
DF/019: Fix error with update and index in same action.

### DIFF
--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -71,7 +71,7 @@ function constructActionJson($row) {
   }
 
   if (isset($row['_parent'])) {
-    $action['index']['_parent'] = $row['_parent'];
+    $action[$act]['_parent'] = $row['_parent'];
   }
 
   return $action;


### PR DESCRIPTION
Sub-PR from #292 
---

Current script can produce an action JSON in form
{"update":{...}, "index":{"_parent":...}} which makes no sense. This occurs
when the input JSON contains "_update" set to true and "_parent" set to
anything. Probably missed instance of "index" that should have been changed
to "$act" when the latter was introduced.

---

This commit is moved to a separate PR for it affects the integration process management and we need it in `master` ASAP.