### PR TITLE
ES/queries: add query example for campaign statistics.

### DIFF
--- a/Utils/Elasticsearch/requests/campaign-stat-jq-parser
+++ b/Utils/Elasticsearch/requests/campaign-stat-jq-parser
@@ -1,0 +1,39 @@
+{
+  tasks_processing_summary: (
+    .aggregations.steps.buckets |
+      map({
+        (.key) : (
+          {total: .doc_count} +
+          (.status.buckets | 
+            map({(.key) : .doc_count}) |
+            add)
+          )
+      }) |
+      add
+  ),
+  overall_events_processing_summary: (
+    .aggregations.steps.buckets |
+      map({
+        (.key) : {
+          input: .input_events.value,
+          output: .output_events.output_events.value,
+          ratio: (.output_events.output_events.value / .input_events.value)
+        }
+      }) |
+      add
+  ),
+  tasks_updated_24h: (
+    .aggregations.steps.buckets |
+      map({
+        (.key): (
+          .status.buckets | 
+          map({ (.key): {
+            total: .doc_count,
+            updated: .updated_24h.doc_count
+          }}) |
+          add
+        )
+      }) |
+      add
+  )
+}

--- a/Utils/Elasticsearch/requests/campaign-stat-q.json
+++ b/Utils/Elasticsearch/requests/campaign-stat-q.json
@@ -14,9 +14,6 @@ GET /production_tasks/task/_search?pretty
     }
   },
   "aggs": {
-    "end": {
-      "max": {"field": "task_timestamp"}
-    },
     "steps": {
       "terms": {
         "field": "step_name.keyword",

--- a/Utils/Elasticsearch/requests/campaign-stat-q.json
+++ b/Utils/Elasticsearch/requests/campaign-stat-q.json
@@ -1,0 +1,56 @@
+/* Overall events processing summary.
+
+For now tasks are selected by (fixed set of) PR_IDs, but for real-life usage
+this part should be reconsidered.
+
+GET /production_tasks/task/_search?pretty
+*/
+{
+  "size": 0,
+  "query": {
+    "terms": {
+      "pr_id": [ 11035, 11034, 11048, 11049, 11050, 11051,
+                 11052, 11198, 11197, 11222, 11359 ]
+    }
+  },
+  "aggs": {
+    "end": {
+      "max": {"field": "task_timestamp"}
+    },
+    "steps": {
+      "terms": {
+        "field": "step_name.keyword",
+        "size": 20
+      },
+      "aggs": {
+        "status": {
+          "terms": {
+            "field": "status",
+            "size": 20
+          },
+          "aggs": {
+            "updated_24h": {
+              "filter": {
+                "range": {
+/*                  "task_timestamp": {"gte": "now-1d"} */
+                  "task_timestamp": {"gte": "20-12-2018 00:00:00"}
+                }
+              }
+            }
+          }
+        },
+        "input_events": {
+          "sum": {"field": "requested_events"}
+        },
+        "output_events": {
+          "children": {"type": "output_dataset"},
+          "aggs": {
+            "output_events": {
+              "sum": {"field": "events"}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Utils/Elasticsearch/requests/campaign-stat-q.json
+++ b/Utils/Elasticsearch/requests/campaign-stat-q.json
@@ -1,4 +1,4 @@
-/* Overall events processing summary.
+/* Campaign processing summary.
 
 For now tasks are selected by (fixed set of) PR_IDs, but for real-life usage
 this part should be reconsidered.

--- a/Utils/Elasticsearch/requests/campaign-stat-r-parsed.json
+++ b/Utils/Elasticsearch/requests/campaign-stat-r-parsed.json
@@ -1,0 +1,183 @@
+{
+  "tasks_processing_summary": {
+    "Simul": {
+      "total": 777,
+      "done": 632,
+      "finished": 111,
+      "aborted": 30,
+      "obsolete": 3,
+      "broken": 1
+    },
+    "Deriv": {
+      "total": 758,
+      "done": 630,
+      "finished": 117,
+      "obsolete": 11
+    },
+    "Deriv Merge": {
+      "total": 758,
+      "done": 630,
+      "finished": 117,
+      "obsolete": 11
+    },
+    "Rec Merge": {
+      "total": 751,
+      "done": 631,
+      "finished": 116,
+      "aborted": 2,
+      "obsolete": 2
+    },
+    "Reco": {
+      "total": 751,
+      "done": 636,
+      "finished": 111,
+      "aborted": 2,
+      "obsolete": 2
+    },
+    "Merge": {
+      "total": 19,
+      "finished": 14,
+      "done": 2,
+      "obsolete": 2,
+      "aborted": 1
+    }
+  },
+  "overall_events_processing_summary": {
+    "Simul": {
+      "input": 2430259640,
+      "output": 1975894120,
+      "ratio": 0.8130382809632637
+    },
+    "Deriv": {
+      "input": 2037850000,
+      "output": 0,
+      "ratio": 0
+    },
+    "Deriv Merge": {
+      "input": 2067300000,
+      "output": 0,
+      "ratio": 0
+    },
+    "Rec Merge": {
+      "input": 2025718000,
+      "output": 2010623450,
+      "ratio": 0.9925485432819375
+    },
+    "Reco": {
+      "input": 2025729800,
+      "output": 0,
+      "ratio": 0
+    },
+    "Merge": {
+      "input": 29282050,
+      "output": 28740350,
+      "ratio": 0.9815006121497641
+    }
+  },
+  "tasks_updated_24h": {
+    "Simul": {
+      "done": {
+        "total": 632,
+        "updated": 0
+      },
+      "finished": {
+        "total": 111,
+        "updated": 0
+      },
+      "aborted": {
+        "total": 30,
+        "updated": 0
+      },
+      "obsolete": {
+        "total": 3,
+        "updated": 0
+      },
+      "broken": {
+        "total": 1,
+        "updated": 0
+      }
+    },
+    "Deriv": {
+      "done": {
+        "total": 630,
+        "updated": 6
+      },
+      "finished": {
+        "total": 117,
+        "updated": 3
+      },
+      "obsolete": {
+        "total": 11,
+        "updated": 9
+      }
+    },
+    "Deriv Merge": {
+      "done": {
+        "total": 630,
+        "updated": 6
+      },
+      "finished": {
+        "total": 117,
+        "updated": 3
+      },
+      "obsolete": {
+        "total": 11,
+        "updated": 9
+      }
+    },
+    "Rec Merge": {
+      "done": {
+        "total": 631,
+        "updated": 0
+      },
+      "finished": {
+        "total": 116,
+        "updated": 0
+      },
+      "aborted": {
+        "total": 2,
+        "updated": 0
+      },
+      "obsolete": {
+        "total": 2,
+        "updated": 0
+      }
+    },
+    "Reco": {
+      "done": {
+        "total": 636,
+        "updated": 0
+      },
+      "finished": {
+        "total": 111,
+        "updated": 0
+      },
+      "aborted": {
+        "total": 2,
+        "updated": 0
+      },
+      "obsolete": {
+        "total": 2,
+        "updated": 0
+      }
+    },
+    "Merge": {
+      "finished": {
+        "total": 14,
+        "updated": 0
+      },
+      "done": {
+        "total": 2,
+        "updated": 0
+      },
+      "obsolete": {
+        "total": 2,
+        "updated": 0
+      },
+      "aborted": {
+        "total": 1,
+        "updated": 0
+      }
+    }
+  }
+}

--- a/Utils/Elasticsearch/requests/campaign-stat-r.json
+++ b/Utils/Elasticsearch/requests/campaign-stat-r.json
@@ -12,10 +12,6 @@
     "hits" : [ ]
   },
   "aggregations" : {
-    "end" : {
-      "value" : 1.545574725E12,
-      "value_as_string" : "23-12-18 14:18:45"
-    },
     "steps" : {
       "doc_count_error_upper_bound" : 0,
       "sum_other_doc_count" : 0,

--- a/Utils/Elasticsearch/requests/campaign-stat-r.json
+++ b/Utils/Elasticsearch/requests/campaign-stat-r.json
@@ -1,0 +1,301 @@
+{
+  "took" : 5,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 4,
+    "successful" : 4,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 3814,
+    "max_score" : 0.0,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "end" : {
+      "value" : 1.545574725E12,
+      "value_as_string" : "23-12-18 14:18:45"
+    },
+    "steps" : {
+      "doc_count_error_upper_bound" : 0,
+      "sum_other_doc_count" : 0,
+      "buckets" : [
+        {
+          "key" : "Simul",
+          "doc_count" : 777,
+          "input_events" : {
+            "value" : 2.43025964E9
+          },
+          "output_events" : {
+            "doc_count" : 777,
+            "output_events" : {
+              "value" : 1.97589412E9
+            }
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 632,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 111,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "aborted",
+                "doc_count" : 30,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "obsolete",
+                "doc_count" : 3,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "broken",
+                "doc_count" : 1,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Deriv",
+          "doc_count" : 758,
+          "input_events" : {
+            "value" : 2.03785E9
+          },
+          "output_events" : {
+            "doc_count" : 758,
+            "output_events" : {
+              "value" : 0.0
+            }
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 630,
+                "updated_24h" : {
+                  "doc_count" : 6
+                }
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 117,
+                "updated_24h" : {
+                  "doc_count" : 3
+                }
+              },
+              {
+                "key" : "obsolete",
+                "doc_count" : 11,
+                "updated_24h" : {
+                  "doc_count" : 9
+                }
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Deriv Merge",
+          "doc_count" : 758,
+          "input_events" : {
+            "value" : 2.0673E9
+          },
+          "output_events" : {
+            "doc_count" : 758,
+            "output_events" : {
+              "value" : 0.0
+            }
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 630,
+                "updated_24h" : {
+                  "doc_count" : 6
+                }
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 117,
+                "updated_24h" : {
+                  "doc_count" : 3
+                }
+              },
+              {
+                "key" : "obsolete",
+                "doc_count" : 11,
+                "updated_24h" : {
+                  "doc_count" : 9
+                }
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Rec Merge",
+          "doc_count" : 751,
+          "input_events" : {
+            "value" : 2.025718E9
+          },
+          "output_events" : {
+            "doc_count" : 749,
+            "output_events" : {
+              "value" : 2.01062345E9
+            }
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 631,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 116,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "aborted",
+                "doc_count" : 2,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "obsolete",
+                "doc_count" : 2,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Reco",
+          "doc_count" : 751,
+          "input_events" : {
+            "value" : 2.0257298E9
+          },
+          "output_events" : {
+            "doc_count" : 751,
+            "output_events" : {
+              "value" : 0.0
+            }
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "done",
+                "doc_count" : 636,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "finished",
+                "doc_count" : 111,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "aborted",
+                "doc_count" : 2,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "obsolete",
+                "doc_count" : 2,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "key" : "Merge",
+          "doc_count" : 19,
+          "input_events" : {
+            "value" : 2.928205E7
+          },
+          "output_events" : {
+            "doc_count" : 19,
+            "output_events" : {
+              "value" : 2.874035E7
+            }
+          },
+          "status" : {
+            "doc_count_error_upper_bound" : 0,
+            "sum_other_doc_count" : 0,
+            "buckets" : [
+              {
+                "key" : "finished",
+                "doc_count" : 14,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "done",
+                "doc_count" : 2,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "obsolete",
+                "doc_count" : 2,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              },
+              {
+                "key" : "aborted",
+                "doc_count" : 1,
+                "updated_24h" : {
+                  "doc_count" : 0
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Example files:
*  `*-q.json`  -- ES query example
*  `*-jq-parser`  -- parsing instructions for command-line JSON processor `jq`
*  `*-r.json` -- ES response
*  `*-r-parsed.json` -- ES response, parsed with `jq`

Command-line instructions:
* to execute the query:
  ```
  curl -u <user>:<passwd> \
    -X GET 'http://aiatlas171.cern.ch:9200' \
    -H 'Content-type: application/json' \
    -d @campaign-stat-q.json \
    | less
  ```

* to parse query results with `jq`:
  ```
  curl <...> \
    | jq -f campaign-stat-jq-parser \
    | less
  ```