### PR TITLE
API: add new method (campaign/stat).

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200129'
+__version__ = '0.2.dev20200219'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -286,3 +286,23 @@ def task_deriv(path, **kwargs):
 
 
 methods.add('/task', 'deriv', task_deriv)
+
+
+def campaign_stat(path, **kwargs):
+    """ Calculate values for campaign progress overview.
+
+    :param path: full path to the method
+    :type path: str
+    :param htag: hashtag to select campaign tasks
+    :type htag: str, list
+
+    :return: calculated campaign statistics
+    :rtype: dict
+    """
+    method_name = '/campaign/stat'
+    if 'htag' not in kwargs:
+        raise MissedArgument(method_name, 'htag')
+    return storages.campaign_stat(**kwargs)
+
+
+methods.add('/campaign', 'stat', campaign_stat)

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -111,3 +111,46 @@ def task_derivation_statistics(**kwargs):
     :rtype: dict
     """
     return es.task_derivation_statistics(**kwargs)
+
+
+def campaign_stat(**kwargs):
+    """ Calculate values for campaign progress overview.
+
+    :param path: full path to the method
+    :type path: str
+    :param htag: hashtag to select campaign tasks
+    :type htag: str, list
+
+    :return: calculated campaign statistics:
+             { _took_storage_ms: <storage query execution time in ms>,
+               _total: <total number of matching tasks>,
+               _errors: [..., <error message>, ...],
+               _data: {
+                 'tasks_processing_summary': {
+                   <step>: {<status>: <n_tasks>, ...},
+                   ...
+                 },
+                 'overall_events_processing_summary': {
+                   <step>: {
+                     'input': <n_events>,
+                     'output': <n_events>,
+                     'ratio': <output>/<input>
+                   },
+                   ...
+                 },
+                 'tasks_updated_24h': {
+                   <step>: {
+                     <status>: {
+                       'total': <n_tasks>,
+                       'updated': <n_tasks>
+                     },
+                     ...
+                   }
+                 }
+               }
+             }
+             (field `_errors` may be omitted if no error has occured)
+    :rtype: dict
+    """
+    return es.campaign_stat(**kwargs)
+

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -153,4 +153,3 @@ def campaign_stat(**kwargs):
     :rtype: dict
     """
     return es.campaign_stat(**kwargs)
-

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -126,26 +126,27 @@ def campaign_stat(**kwargs):
                _total: <total number of matching tasks>,
                _errors: [..., <error message>, ...],
                _data: {
-                 'tasks_processing_summary': {
+                 tasks_processing_summary: {
                    <step>: {<status>: <n_tasks>, ...},
                    ...
                  },
-                 'overall_events_processing_summary': {
+                 overall_events_processing_summary: {
                    <step>: {
-                     'input': <n_events>,
-                     'output': <n_events>,
-                     'ratio': <output>/<input>
+                     input: <n_events>,
+                     output: <n_events>,
+                     ratio: <output>/<input>
                    },
                    ...
                  },
-                 'tasks_updated_24h': {
+                 tasks_updated_24h: {
                    <step>: {
                      <status>: {
-                       'total': <n_tasks>,
-                       'updated': <n_tasks>
+                       total: <n_tasks>,
+                       updated: <n_tasks>
                      },
                      ...
-                   }
+                   },
+                   ...
                  }
                }
              }

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -589,3 +589,45 @@ def task_derivation_statistics(**kwargs):
             data.append(r)
     result = {'_data': data}
     return result
+
+
+def campaign_stat(**kwargs):
+    """ Calculate values for campaign progress overview.
+
+    :param path: full path to the method
+    :type path: str
+    :param htag: hashtag to select campaign tasks
+    :type htag: str, list
+
+    :return: calculated campaign statistics:
+             { _took_storage_ms: <storage query execution time in ms>,
+               _total: <total number of matching tasks>,
+               _errors: [..., <error message>, ...],
+               _data: {
+                 'tasks_processing_summary': {
+                   <step>: {<status>: <n_tasks>, ...},
+                   ...
+                 },
+                 'overall_events_processing_summary': {
+                   <step>: {
+                     'input': <n_events>,
+                     'output': <n_events>,
+                     'ratio': <output>/<input>
+                   },
+                   ...
+                 },
+                 'tasks_updated_24h': {
+                   <step>: {
+                     <status>: {
+                       'total': <n_tasks>,
+                       'updated': <n_tasks>
+                     },
+                     ...
+                   }
+                 }
+               }
+             }
+             (field `_errors` may be omitted if no error has occured)
+    :rtype: dict
+    """
+    raise DkbApiNotImplemented()

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -602,8 +602,8 @@ def _transform_campaign_stat(stat_data):
     """
     r = {}
     data = {}
-    r['_took_storage_ms'] = data.pop('took', None)
-    r['_total'] = data.get('hits', {}).pop('total', None)
+    r['_took_storage_ms'] = stat_data.pop('took', None)
+    r['_total'] = stat_data.get('hits', {}).pop('total', None)
     r['_data'] = data
 
     data['tasks_processing_summary'] = {}

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -654,26 +654,27 @@ def campaign_stat(**kwargs):
                _total: <total number of matching tasks>,
                _errors: [..., <error message>, ...],
                _data: {
-                 'tasks_processing_summary': {
+                 tasks_processing_summary: {
                    <step>: {<status>: <n_tasks>, ...},
                    ...
                  },
-                 'overall_events_processing_summary': {
+                 overall_events_processing_summary: {
                    <step>: {
-                     'input': <n_events>,
-                     'output': <n_events>,
-                     'ratio': <output>/<input>
+                     input: <n_events>,
+                     output: <n_events>,
+                     ratio: <output>/<input>
                    },
                    ...
                  },
-                 'tasks_updated_24h': {
+                 tasks_updated_24h: {
                    <step>: {
                      <status>: {
-                       'total': <n_tasks>,
-                       'updated': <n_tasks>
+                       total: <n_tasks>,
+                       updated: <n_tasks>
                      },
                      ...
-                   }
+                   },
+                   ...
                  }
                }
              }

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -616,13 +616,13 @@ def _transform_campaign_stat(stat_data):
     for step in steps:
         # Events processing summary
         eps = {'input': step.get('input_events', {}).get('value', None),
-               'output': step.get('output_events', {}) \
-                             .get('output_events', {}) \
+               'output': step.get('output_events', {})
+                             .get('output_events', {})
                              .get('value', None),
                'ratio': None
-              }
+               }
         if eps['input'] and eps['output']:
-            eps['ratio'] = eps['output']/eps['input']
+            eps['ratio'] = eps['output'] / eps['input']
 
         # Tasks processing: summary and updates
         tps = {'total': step['doc_count']}

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
@@ -1,0 +1,42 @@
+{
+  "size": 0,
+  "query": {
+    "terms": {"hashtag_list": %(htags)s}
+  },
+  "aggs": {
+    "steps": {
+      "terms": {
+        "field": "step_name.keyword",
+        "size": 20
+      },
+      "aggs": {
+        "status": {
+          "terms": {
+            "field": "status",
+            "size": 20
+          },
+          "aggs": {
+            "updated_24h": {
+              "filter": {
+                "range": {
+                  "task_timestamp": {"gte": "now-1d"}
+                }
+              }
+            }
+          }
+        },
+        "input_events": {
+          "sum": {"field": "requested_events"}
+        },
+        "output_events": {
+          "children": {"type": "output_dataset"},
+          "aggs": {
+            "output_events": {
+              "sum": {"field": "events"}
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added new API method: `campaign/stat`.
The method accepts following parameters:
* `?htag=...&htag=...` -- hashtag (or number of hashtags); for statistics will be selected all tasks marked with at least one of the passed hashtags (logical `OR`).

Example URL: http://aiatlas172:5080/campaign/stat?htag=newfastcalosimntuponly&pretty

JSON response has following format *(field `errors` may be omitted if no error has occured)*:
```
{
  status: <OK/failed>,
  took_storage_ms: <storage query execution time in ms>,
  total: <total number of matching tasks>,
  errors: [..., <error message>, ...],
  data: {
    'tasks_processing_summary': {
      <step>: {<status>: <n_tasks>, ...},
      ...
    },
    'overall_events_processing_summary': {
      <step>: {
        'input': <n_events>,
        'output': <n_events>,
        'ratio': <output>/<input>
      },
      ...
    },
    'tasks_updated_24h': {
      <step>: {
        <status>: {
          'total': <n_tasks>,
          'updated': <n_tasks>
        },
        ...
      },
      ...
    }
  }
}
```

---

This is a "draft" version of this method: most likely, input parameters will change. Output format also may change.