### PR TITLE
API/campaign_stat: add steps timing info.

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200219'
+__version__ = '0.2.dev20200220'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -126,8 +126,14 @@ def campaign_stat(**kwargs):
                _total: <total number of matching tasks>,
                _errors: [..., <error message>, ...],
                _data: {
+                 last_update: <last_registered_task_timestamp>,
+                 date_format: <datetime_format>,
                  tasks_processing_summary: {
-                   <step>: {<status>: <n_tasks>, ...},
+                   <step>: {
+                     <status>: <n_tasks>, ...,
+                     start: <earliest_start_time>,
+                     end: <latest_end_time>
+                   },
                    ...
                  },
                  overall_events_processing_summary: {

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
@@ -35,8 +35,17 @@
               "sum": {"field": "events"}
             }
           }
+        },
+        "start": {
+          "min": {"field": "start_time"}
+        },
+        "end": {
+          "max": {"field": "end_time"}
         }
       }
+    },
+    "last_update": {
+      "max": {"field": "task_timestamp"}
     }
   }
 }


### PR DESCRIPTION
New fields in the method response:
* `data['last_update']` -- last registered timestamp for selected tasks;
* `data['date_format']` -- format for datetime fields parsing (in terms of Python `datetime` module);
* `data[<step>]['start'] -- earliest `start_time` for given step;
* `data[<step>]['end'] -- latest `end_time` for given step.