### PR TITLE
API/campaign_statistics: update

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200220'
+__version__ = '0.2.dev20200222'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -295,13 +295,29 @@ def campaign_stat(path, **kwargs):
     :type path: str
     :param htag: hashtag to select campaign tasks
     :type htag: str, list
+    :param events_src: source of data for 'output' events.
+                       Possible values:
+                       * 'ds'   -- number of events in output datasets
+                                   (default);
+                       * 'task' -- number of processed events of 'done'
+                                   and 'finished' tasks;
+                       * 'all'  -- provide all possible values as hash.
+    :type events_src: str
 
     :return: calculated campaign statistics
     :rtype: dict
     """
     method_name = '/campaign/stat'
+    events_src_values = ['ds', 'task', 'all']
     if 'htag' not in kwargs:
         raise MissedArgument(method_name, 'htag')
+    if 'events_src' in kwargs:
+        if kwargs['events_src'] not in events_src_values:
+            raise InvalidArgument(method_name, ('events_src',
+                                                kwargs['events_src'],
+                                                events_src_values))
+    else:
+        kwargs['events_src'] = events_src_values[0]
     return storages.campaign_stat(**kwargs)
 
 

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -120,6 +120,13 @@ def campaign_stat(**kwargs):
     :type path: str
     :param htag: hashtag to select campaign tasks
     :type htag: str, list
+    :param events_src: source of data for 'output' events.
+                       Possible values:
+                       * 'ds'   -- number of events in output datasets;
+                       * 'task' -- number of processed events of 'done'
+                                   and 'finished' tasks;
+                       * 'all'  -- provide all possible values as hash.
+    :type events_src: str
 
     :return: calculated campaign statistics:
              { _took_storage_ms: <storage query execution time in ms>,
@@ -141,6 +148,7 @@ def campaign_stat(**kwargs):
                      input: <n_events>,
                      output: <n_events>,
                      ratio: <output>/<input>
+                            /* null if 'events_src' is 'all' */
                    },
                    ...
                  },

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -153,6 +153,10 @@ def campaign_stat(**kwargs):
                      ...
                    },
                    ...
+                 },
+                 events_24h: {
+                   <step>: <n_output_events_for_done_finisfed>,
+                   ...
                  }
                }
              }

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -10,7 +10,8 @@ import json
 from datetime import datetime
 import time
 
-from ..exceptions import DkbApiNotImplemented
+from ..exceptions import (DkbApiNotImplemented,
+                          MethodException)
 from exceptions import (StorageClientException,
                         QueryNotFound,
                         MissedParameter,
@@ -713,11 +714,11 @@ def campaign_stat(**kwargs):
         data = _transform_campaign_stat(data)
     except KeyError, err:
         msg = "Failed to parse storage response: %s." % str(err)
-        r['_errors'] = r.get('_errors', []) + [msg]
+        raise MethodException(msg)
     except Exception, err:
         msg = "(%s) Failed to execute search query: %s." % (STORAGE_NAME,
                                                             str(err))
-        r['_errors'] = r.get('_errors', []) + [msg]
+        raise MethodException(msg)
 
     r.update(data)
     return r

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -707,6 +707,7 @@ def campaign_stat(**kwargs):
     query_kwargs = {'htags': htags}
     query['body'] = get_query('campaign-stat', **query_kwargs)
     r = {}
+    data = {}
     try:
         data = client().search(**query)
         data = _transform_campaign_stat(data)

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -713,11 +713,11 @@ def campaign_stat(**kwargs):
         data = _transform_campaign_stat(data)
     except KeyError, err:
         msg = "Failed to parse storage response: %s." % str(err)
-        r['_errors'] = r.get('_errors', []).append(msg)
+        r['_errors'] = r.get('_errors', []) + [msg]
     except Exception, err:
         msg = "(%s) Failed to execute search query: %s." % (STORAGE_NAME,
                                                             str(err))
-        r['_errors'] = r.get('_errors', []).append(msg)
+        r['_errors'] = r.get('_errors', []) + [msg]
 
     r.update(data)
     return r

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
@@ -35,6 +35,9 @@
                           "sum": {"field": "events"}
                         }
                       }
+                    },
+                    "processed_events": {
+                      "sum": {"field": "processed_events"}
                     }
                   }
                 }
@@ -50,6 +53,16 @@
           "aggs": {
             "output_events": {
               "sum": {"field": "events"}
+            }
+          }
+        },
+        "finished": {
+          "filter": {
+            "terms": {"status": ["done", "finished"]}
+          },
+          "aggs": {
+            "processed_events": {
+              "sum": {"field": "processed_events"}
             }
           }
         },

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
@@ -21,6 +21,23 @@
                 "range": {
                   "task_timestamp": {"gte": "now-1d"}
                 }
+              },
+              "aggs": {
+                "finished": {
+                  "filter": {
+                    "terms": {"status": ["done", "finished"]}
+                  },
+                  "aggs": {
+                    "output": {
+                      "children": {"type": "output_dataset"},
+                      "aggs": {
+                        "events": {
+                          "sum": {"field": "events"}
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Main changes:
* new section in response: `data['events_24h']`;
* new parameter `events_src` to specify method to calculate output events number.

---

With the new option can be altered valued of the following fields:
* data['overall_events_processing_summary'][<step>]['output'];
* data['events_24h'][<step>].

Parameter `events_src` accepts values:
* `'ds'` -- use output datasets version (same as before) (default);
* `'task'` -- use `processed_events`;
* `'all'`  -- provide all possible values as hash.

Response format (with `events_src` set to `'ds'` or `'task'`):
```
{
  took_storage_ms: <storage query execution time in ms>,
  total: <total number of matching tasks>,
  errors: [..., <error message>, ...],
  data: {
    last_update: <last_registered_task_timestamp>,
    date_format: <datetime_format>,
    tasks_processing_summary: {
      <step>: {
        start: <earliest_start_time>,
        end: <latest_end_time>
        <status>: <n_tasks>,
        ...
      },
      ...
    },
    overall_events_processing_summary: {
      <step>: {
        input: <n_events>,
        output: <n_events>,
        ratio: <output>/<input>
      },
      ...
    },
    tasks_updated_24h: {
      <step>: {
        <status>: {
          total: <n_tasks>,
          updated: <n_tasks>
        },
      ...
    },
    events_24h: {
      <step>: <n_output_events_for_done_finisfed>,
      ...
    },
    <...>
  }
}
```

If `events_src` is set to `'all'`:
```
{
  ...,
  data: {
    ...,
    overall_events_processing_summary: {
      <step>: {
        input: <n_events>,
        output: {
          'ds': <n_events_in_output_datasets>,
          'task': <n_processed_events_of_done_and_finished_tasks>
        },
        ratio: null
      },
      ...
    },
    ...,
    events_24h: {
      <step>: {
          'ds': <n_events_in_output_datasets>,
          'task': <n_processed_events_of_done_and_finished_tasks>
        },
      ...
    },
    <...>
  }
}
```