### PR TITLE
API/campaign_stat: improve input events calculation.

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200222'
+__version__ = '0.2.dev20200222.1'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat
@@ -46,7 +46,7 @@
           }
         },
         "input_events": {
-          "sum": {"field": "requested_events"}
+          "sum": {"field": "input_events"}
         },
         "output_events": {
           "children": {"type": "output_dataset"},


### PR DESCRIPTION
Previously was used value of `requested_events` field [1], now it is
`input_events` [2].

---

[1] `requested_events` is taken from `ATLAS_PANDA.JEDI_DATASETS.nevents`
    of task's 'input' dataset

[2] `input_events` is taken as:
  * for EVNT tasks:
    * if defined `n_files_to_be_used` [3]:
      `n_files_to_be_used * n_events_per_job / (n_files_per_job|1)`;
    * if not defined `n_files_to_be_used`:
      `processed_events`;
  * for other tasks:
    `min(requested_events, primary_input_events)`.

[3] Origins of values for `input_events` calculation:
  * `n_files_to_be_used`: ATLAS_DEFT.T_PRODUCTION_TASK.nfilestobeused;
  * `n_events_per_job`: JEDI task parameter `nEventsPerJob`;
  * `n_files_per_job`: JEDI task parameter `nFilesPerJob` (if not
      defined, will be taken as 1).