### PR TITLE
DF/069: error logging

### DIFF
--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -39,7 +39,7 @@ jq_response_parser='
     | "Failed to load record: " + ( {(._id): .error} | tostring )
   ),
   (
-    select(.error) | "Failed to load record:" + (.error|tostring)
+    select(.error) | "Failed to load record: " + (.error|tostring)
   )'
 
 parse_bulk_response() {

--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -95,6 +95,7 @@ load_files () {
     ${cmd}${INPUTFILE} | parse_bulk_response
     [ ${PIPESTATUS[0]} -ne 0 ] && exit 3
   done
+  return 0
 }
 
 load_stream () {
@@ -109,6 +110,7 @@ load_stream () {
     { echo "$line" | ${cmd}- | parse_bulk_response; } &
     echo -n "$EOProcess"
   done
+  return 0
 }
 
 if [ -z "$1" ] ; then

--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-log() {
-  echo "$(date): $*" >&2
-}
 
 usage() {
   echo "USAGE:
@@ -16,6 +13,9 @@ PARAMETERS:
 base_dir=$( cd "$( dirname "$( readlink -f "$0" )" )" && pwd )
 
 ES_CONFIG="${base_dir}/../../Elasticsearch/config/es"
+
+. "$base_dir"/../shell_lib/log
+
 
 while [ -n "$1" ]; do
   case "$1" in

--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -93,7 +93,7 @@ load_files () {
   do
     cat ${INPUTFILE} | verify_ndjson
     ${cmd}${INPUTFILE} | parse_bulk_response
-    [ $PIPESTATUS[0] -ne 0 ] && exit 3
+    [ ${PIPESTATUS[0]} -ne 0 ] && exit 3
   done
 }
 

--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -39,7 +39,7 @@ jq_response_parser='
     | "Failed to load record: " + ( {(._id): .error} | tostring )
   ),
   (
-    select(.error) | "Failed to load record:" + .error|tostring
+    select(.error) | "Failed to load record:" + (.error|tostring)
   )'
 
 parse_bulk_response() {


### PR DESCRIPTION
Changes:
* input data verification (to check at least that NDJSON consists of JSONs);
* ES bulk API response parsing:
  * to have information on failed load attempts;
  * to know how many records were loaded (bulk API may simply skip records with broken `action` string).