### PR TITLE
Fix a typo.

### DIFF
--- a/Utils/Elasticsearch/mapping/tasks.mapping
+++ b/Utils/Elasticsearch/mapping/tasks.mapping
@@ -130,7 +130,7 @@
         "core_count": {
           "type": "short"
         },
-        "conditions_tag": {
+        "conditions_tags": {
           "type": "keyword",
           "ignore_above": 2048
         },


### PR DESCRIPTION
This mapping is the only place where the field name lacks "s" at the end.
Everywhere else - in Stage 009, data samples, DKB's ES - the other version
is used. I presume that this is a typo, and the actual mapping used in our
ES was "fine-tuned by a file" (or not touched at all, given how
ES's dynamic mapping works).