### PR TITLE
API: rename `task/stat` to `step/stat`.

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200305'
+__version__ = '0.2.dev20200305.1'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -357,7 +357,7 @@ def campaign_stat(path, **kwargs):
 methods.add('/campaign', 'stat', campaign_stat)
 
 
-def task_stat(path, rtype='json', step_type=None, **kwargs):
+def step_stat(path, rtype='json', step_type=None, **kwargs):
     """ Get tasks statistics.
 
     :param path: full path to the method
@@ -394,7 +394,7 @@ def task_stat(path, rtype='json', step_type=None, **kwargs):
 
     :rtype: dict
     """
-    method_name = '/task/stat'
+    method_name = '/step/stat'
     if rtype is not 'json':
         raise MethodException(method_name, "Unsupported response type: '%s'"
                                            % rtype)
@@ -415,7 +415,7 @@ def task_stat(path, rtype='json', step_type=None, **kwargs):
     logging.debug('(%s) parsed parameters:\n%s' % (method_name,
                                                    json.dumps(params,
                                                               indent=2)))
-    r = storages.task_stat(step_type=step_type, selection_params=params)
+    r = storages.step_stat(step_type=step_type, selection_params=params)
     if step_type == 'step':
         def steps_cmp(x, y):
             """ Compare processing steps for ordering. """
@@ -441,4 +441,4 @@ def task_stat(path, rtype='json', step_type=None, **kwargs):
     return r
 
 
-methods.add('/task', 'stat', task_stat)
+methods.add('/step', 'stat', step_stat)

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -175,7 +175,7 @@ def campaign_stat(**kwargs):
     return es.campaign_stat(**kwargs)
 
 
-def task_stat(**kwargs):
+def step_stat(**kwargs):
     """ Calculate statistics for tasks by execution steps.
 
     :param selection_params: hash of parameters defining task selections
@@ -213,4 +213,4 @@ def task_stat(**kwargs):
              ```
     :rtype: hash
     """
-    return es.task_stat(**kwargs)
+    return es.step_stat(**kwargs)

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -1201,7 +1201,7 @@ def _get_stat_values(data, units=[]):
     return result
 
 
-def _transform_task_stat(data, agg_units=[], step_type=None):
+def _transform_step_stat(data, agg_units=[], step_type=None):
     """ Transform ES query response to required response format.
 
     :param data: ES response
@@ -1313,7 +1313,7 @@ def _transform_task_stat(data, agg_units=[], step_type=None):
     return r
 
 
-def task_stat(selection_params, step_type='step'):
+def step_stat(selection_params, step_type='step'):
     """ Calculate statistics for tasks by execution steps.
 
     :param selection_params: hash of parameter defining task selection
@@ -1394,7 +1394,7 @@ def task_stat(selection_params, step_type='step'):
     r = client().search(**query)
     logging.debug('ES response:\n%s' % json.dumps(r, indent=2))
     # ...and parse its response
-    r = _transform_task_stat(r, agg_units, step_type)
+    r = _transform_step_stat(r, agg_units, step_type)
     if WARNINGS.get('output_formats'):
         r['_warning'] = WARNINGS['output_formats']
     return r


### PR DESCRIPTION
Method `/task/stat` is renamed to `/step/stat`.

The method was not announced to anyone yet, so it is OK to change its name without second thought about backward compatibility.