### PR TITLE
API: fix step stat warning

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200305.1'
+__version__ = '0.2.dev20200305.2'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/storages/es.py
+++ b/Utils/API/server/lib/dkb/api/storages/es.py
@@ -1395,6 +1395,6 @@ def step_stat(selection_params, step_type='step'):
     logging.debug('ES response:\n%s' % json.dumps(r, indent=2))
     # ...and parse its response
     r = _transform_step_stat(r, agg_units, step_type)
-    if WARNINGS.get('output_formats'):
+    if step_type == 'ctag_format' and WARNINGS.get('output_formats'):
         r['_warning'] = WARNINGS['output_formats']
     return r


### PR DESCRIPTION
Remove warning about excluded data formats in case of 'step' steps ('cause resulting data are not based on data formats).