### PR TITLE
pyDKB/test: test line numbers

### DIFF
--- a/Utils/Dataflow/test/pyDKB/case/20/err
+++ b/Utils/Dataflow/test/pyDKB/case/20/err
@@ -14,19 +14,19 @@
 (INFO) (ProcessorStage) Starting stage execution.
 (ERROR) (ProcessorStage) File already exists: ./input/out/NDjson.ttl
 (DEBUG) (ProcessorStage) Traceback (most recent call last):
-(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line 232, in run
+(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line <NNN>, in run
 (==)     self.flush_buffer()
-(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line 341, in flush_buffer
+(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line <NNN>, in flush_buffer
 (==)     self.__output.flush()
-(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line 107, in flush
+(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line <NNN>, in flush
 (==)     self.get_stream().flush()
-(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line 54, in get_stream
+(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line <NNN>, in get_stream
 (==)     self.reset_stream()
-(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line 64, in reset_stream
+(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line <NNN>, in reset_stream
 (==)     dest = self.get_dest()
-(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line 60, in get_dest
+(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line <NNN>, in get_dest
 (==)     self.reset_file()
-(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line 171, in reset_file
+(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line <NNN>, in reset_file
 (==)     % cur['local_path'])
 (==) ProducerException: File already exists: ./input/out/NDjson.ttl
 (INFO) (ProcessorStage) Stopping stage.

--- a/Utils/Dataflow/test/pyDKB/case/21/err
+++ b/Utils/Dataflow/test/pyDKB/case/21/err
@@ -15,21 +15,21 @@
 (ERROR) (FileProducer) Failed to create output directory
 (==) Error message: [Errno 17] File exists: './input/out'
 (DEBUG) (ProcessorStage) Traceback (most recent call last):
-(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line 232, in run
+(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line <NNN>, in run
 (==)     self.flush_buffer()
-(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line 341, in flush_buffer
+(==)   File "./../../pyDKB/dataflow/stage/ProcessorStage.py", line <NNN>, in flush_buffer
 (==)     self.__output.flush()
-(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line 107, in flush
+(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line <NNN>, in flush
 (==)     self.get_stream().flush()
-(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line 54, in get_stream
+(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line <NNN>, in get_stream
 (==)     self.reset_stream()
-(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line 64, in reset_stream
+(==)   File "./../../pyDKB/dataflow/communication/producer/Producer.py", line <NNN>, in reset_stream
 (==)     dest = self.get_dest()
-(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line 60, in get_dest
+(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line <NNN>, in get_dest
 (==)     self.reset_file()
-(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line 174, in reset_file
+(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line <NNN>, in reset_file
 (==)     self.ensure_dir()
-(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line 123, in ensure_dir
+(==)   File "./../../pyDKB/dataflow/communication/producer/FileProducer.py", line <NNN>, in ensure_dir
 (==)     raise ProducerException
 (==) ProducerException
 (INFO) (ProcessorStage) Stopping stage.

--- a/Utils/Dataflow/test/pyDKB/test.sh
+++ b/Utils/Dataflow/test/pyDKB/test.sh
@@ -54,7 +54,8 @@ test_case() {
   eval "$before $cmd; $after"  2>&1 1> out.tmp | \
     grep -a -v '(WARN) (pyDKB.dataflow.cds) Submodule failed (No module named invenio_client.contrib)' | \
     sed -E -e"s#$base_dir#\$base_dir#" \
-           -e"s#^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} ##" >  err.tmp
+           -e"s#^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} ##" \
+           -e"s#, line [0-9]+#, line <NNN>#" > err.tmp
 
   err_correct=0
   out_correct=0


### PR DESCRIPTION
When pyDKB code is updated, some test cases that contain traceback info
in the expected STDERR, can be broken. From now on all ', line XXX' parts
of these tracebacks in the `case/*/err` can (and should) be written as
', line <NNN>' -- this way, the real line numbers are hidden and their
changes won't affect the test cases.