### PR TITLE
API/campaign_stat: events daily progress.

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200311.3'
+__version__ = '0.2.dev20200320'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -429,8 +429,11 @@ def campaign_stat(path, rtype='json', step_type=None, events_src=None,
           },
           ...
         },
-        "events_24h": {
-          <step>: <n_output_events_for_done_finisfed>,
+        "events_daily_progress": {
+          <step>: {
+            <date>: <n_events_processed_by_tasks_finished_"today">,
+            ...
+          },
           ...
         }
       }

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat-step-aggs
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat-step-aggs
@@ -10,26 +10,6 @@
           "range": {
             "task_timestamp": {"gte": "now-1d"}
           }
-        },
-        "aggs": {
-          "finished": {
-            "filter": {
-              "terms": {"status": ["done", "finished"]}
-            },
-            "aggs": {
-              "output": {
-                "children": {"type": "output_dataset"},
-                "aggs": {
-                  "events": {
-                    "sum": {"field": "events"}
-                  }
-                }
-              },
-              "processed_events": {
-                "sum": {"field": "processed_events"}
-              }
-            }
-          }
         }
       }
     }
@@ -52,6 +32,27 @@
     "aggs": {
       "processed_events": {
         "sum": {"field": "processed_events"}
+      },
+      "daily": {
+        "date_histogram": {
+          "interval": "day",
+          "field": "end_time",
+          "keyed": true,
+          "min_doc_count" : 1
+        },
+        "aggs": {
+          "output": {
+            "children": {"type": "output_dataset"},
+            "aggs": {
+              "events": {
+                "sum": {"field": "events"}
+              }
+            }
+          },
+          "processed_events": {
+            "sum": {"field": "processed_events"}
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
"Daily progress" is not "last day's progress", but "day-by-day
progress". So the method's output data format has changed: instead of
'events_24h' there's now 'events_daily_progress' sections, with data in
the following form:

```
{
  ...
  "data": {
    ...
    "events_daily_progress": {
      <step_name>: {
        <date>: <n_events_processed_by_tasks_finished_'today'>,
        ...
      },
      ...
    }
  }
}
```

Value for `<n_events_processed_by_tasks_finished_'today'>` is calculated
as sum of output events of all tasks with "end_date" within given day's
interval (from <date> 00:00:00 to <date> 23:59:59) and with status
'done' or 'finised'.

Output events, as in other cases for this method, can be calculated
basing on the task's "processed_events" field, or on the number of
events in the task's (not removed) output datasets (see
`?events_src=...` method's parameter).

---

Example of the method's response:

```
{
  "status": "OK",
  "took_total_ms": 960,
  "total": 12682,
  "data": {
    "events_daily_progress": {
      "NTUP:p3474": {
        "08-03-18 00:00:00": 11950000.0,
        "07-03-18 00:00:00": 2430000.0,
        "10-03-18 00:00:00": 150000.0,
        "12-03-18 00:00:00": 80000.0,
        "13-03-18 00:00:00": 10000.0,
        "11-03-18 00:00:00": 90000.0,
        "09-03-18 00:00:00": 950000.0
      },
      "NTUP:r10284": null,
      "NTUP_FCS:p3449": {
        "26-02-18 00:00:00": 618000.0,
        "01-03-18 00:00:00": 68000.0,
        "25-02-18 00:00:00": 570000.0,
        "23-02-18 00:00:00": 1010000.0,
        "24-02-18 00:00:00": 550000.0,
        "28-02-18 00:00:00": 60000.0,
        "22-02-18 00:00:00": 250000.0,
        "27-02-18 00:00:00": 110000.0
      },
      ...
    },
    ...
  }
}
```