### PR TITLE
travis functions (fix): collect lines from files as fixed strigns

### DIFF
--- a/Tests/travis/functions.sh
+++ b/Tests/travis/functions.sh
@@ -14,7 +14,7 @@ getLinesFromFile() {
   lines="$2"
 
   echo "$lines" | sort -u | while IFS= read -r l; do
-      grep -n "^$l\$" -- "$file"
+      grep -Fxn "$l" -- "$file"
   done | sort -n
 }
 


### PR DESCRIPTION
We are useing getLinesFromFile for collecting wrong lines from files in commit/PR.
This funtion use grep to collect all bad strings.
As a default grep assumes that regular expression will be used for search,
  but we are actually searching strings that looks exactly as target string.
So we should search not regular expression, but fixed string.

Fix #349