### PR TITLE
Run pyDKB check in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,8 @@ jobs:
       language: minimal
       name: "Trailing spaces"
       script: Tests/travis/README_trailing_spaces.sh
+
+    - stage: pyDKB_tests
+      language: python
+      python: 2.7
+      script: Tests/travis/pyDKB.sh

--- a/Tests/travis/pyDKB.sh
+++ b/Tests/travis/pyDKB.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+functions="$(dirname $0)/functions.sh"
+if [ -f "$functions" ]; then
+  . "$functions"
+else
+  echo "functions file '$functions' not found!"
+  exit 1
+fi
+
+getChangedFiles | grep -q -e '^Utils/Dataflow/pyDKB' -e '^Utils/Dataflow/test/pyDKB'
+have_files_to_check=$?
+
+e=0
+if [ $have_files_to_check -eq 0 ]; then
+  $(dirname $0)/../../Utils/Dataflow/test/pyDKB/test.sh
+  e=$?
+fi
+exit $e

--- a/Utils/Dataflow/test/pyDKB/test.sh
+++ b/Utils/Dataflow/test/pyDKB/test.sh
@@ -4,6 +4,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+exit_code=0
 # Test stage run modes.
 
 base_dir=$(cd "$(dirname "$(readlink -f "$0")")"; pwd)
@@ -75,8 +76,14 @@ test_case() {
   else
     rm "${case_id}_err.diff"
   fi
+
+  result=0
+
   ! [ -f "${case_id}_err.diff" ] && ! [ -f "${case_id}_out.diff" ] && \
-    echo -e " ${GREEN}OK${NC} : $case_id"
+    echo -e " ${GREEN}OK${NC} : $case_id" || \
+    result=1
+
+  return $result
 }
 
 CASES=""
@@ -123,9 +130,12 @@ rm *.{err,out} 2>/dev/null
 for c in $CASES; do
   if [ -d "$c" ]; then
     test_case $c
+    result=$?
+    [ $exit_code -eq 0 -a $result -eq 1 ] && exit_code=$result
   else
     echo "Invalid test: '$c' (directory not found)." >&2
   fi
 done
 
 cd $orig_dir
+exit $exit_code


### PR DESCRIPTION
We have test script for pyDKB, but we should run it manually.
TravisCI may do it instead of us.
Fix #351 