### PR TITLE
API/campaign_stat: bug and logic fixes.

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.2.dev20200320'
+__version__ = '0.2.dev20200416'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/storages/es/methods.py
+++ b/Utils/API/server/lib/dkb/api/storages/es/methods.py
@@ -311,13 +311,14 @@ def campaign_stat(selection_params, step_type='step', events_src=None):
     data = {}
     try:
         data = client().search(**query)
-        data = transform.campaign_stat(data, events_src)
-    except KeyError, err:
-        msg = "Failed to parse storage response: %s." % str(err)
-        raise MethodException(reason=msg)
     except Exception, err:
         msg = "(%s) Failed to execute search query: %s." % (STORAGE_NAME,
                                                             str(err))
+        raise MethodException(reason=msg)
+    try:
+        data = transform.campaign_stat(data, events_src)
+    except Exception, err:
+        msg = "Failed to parse storage response: %s." % str(err)
         raise MethodException(reason=msg)
 
     r.update(data)

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat-step-aggs
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-stat-step-aggs
@@ -15,7 +15,14 @@
     }
   },
   "input_events": {
-    "sum": {"field": "input_events"}
+    "filter": {
+      "bool": {"must_not": {"terms": {"status": ["aborted", "failed", "broken", "obsolete"]}}}
+    },
+    "aggs": {
+      "input_events": {
+        "sum": {"field": "input_events"}
+      }
+    }
   },
   "output_events": {
     "children": {"type": "output_dataset"},

--- a/Utils/API/server/lib/dkb/api/storages/es/transform.py
+++ b/Utils/API/server/lib/dkb/api/storages/es/transform.py
@@ -399,7 +399,9 @@ def campaign_stat(stat_data, events_src=None):
                             .get('value', None)
         esp_o = esp_o[events_src] if events_src != 'all' else esp_o
 
-        eps = {'input': step.get('input_events', {}).get('value', None),
+        eps = {'input': step.get('input_events', {})
+                            .get('input_events', {})
+                            .get('value', None),
                'output': esp_o,
                'ratio': None
                }

--- a/Utils/API/server/lib/dkb/api/storages/es/transform.py
+++ b/Utils/API/server/lib/dkb/api/storages/es/transform.py
@@ -410,6 +410,9 @@ def campaign_stat(stat_data, events_src=None):
         except TypeError:
             # Values are not numeric (None or dict)
             pass
+        except ZeroDivisionError:
+            # Number of input events is -- somehow -- zero
+            pass
 
         # Tasks processing: summary and updates
         tps = {}


### PR DESCRIPTION
Fixed:
* error handling (now "parsing" errors are distinguished from "query execution" ones more clearly);
* unhandled division by zero;
* 'input_events' calculation logic (only "valid" tasks are taken into account).

Example of the difference in the response -- before and after the last fix
(`?htag=mc16e_pa&events_src=task`):
```
"Evgen Merge": {                │  "Evgen Merge": {
  "input": 361333334.0,         │    "input": 354115246.0,
  "ratio": 0.9800237417342735,  │    "ratio": 1.0,
  "output": 354115246.0         │    "output": 354115246.0
},                              |  },
```