### PR TITLE
[frozen] API: campaign/task events processing daily progress.

### DIFF
--- a/Utils/API/server/dkb.yaml.example
+++ b/Utils/API/server/dkb.yaml.example
@@ -7,3 +7,4 @@ storages:
     index:
       production_tasks: index_name_1
       analysis_tasks: index_name_2
+      daily_progress: index_name_3

--- a/Utils/API/server/lib/dkb/api/storages/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/__init__.py
@@ -91,6 +91,46 @@ def campaign_stat(**kwargs):
     return es.campaign_stat(**kwargs)
 
 
+def campaign_daily_progress(**kwargs):
+    """ Generate events processing daily progress report.
+
+    :param step_type: step definition type: 'step', 'ctag_format'
+                      (default: 'step')
+    :type step_type: str
+
+    :param selection_params: defines conditions to select tasks for
+                             statistics. Parameter names are mapped
+                             to storage record fields (names and/or
+                             aliases). Values should be provided in
+                             one of the following forms:
+                             * ``None`` (field must not be presented
+                               in selected records);
+                             * (list of) exact field value(s).
+                             Field values are broken into categories:
+                             * ``&`` -- field must have all these values;
+                             * ``|`` -- field must have at least one of
+                                        these values;
+                             * ``!`` -- field must not have none of these
+                                        values.
+                             Expected format:
+                             ```
+                             {
+                               <selection_param>: {
+                                 <category>: [<values>],
+                                 ...
+                               },
+                               ...
+                             }
+                             ```
+    :type selection_params: dict
+
+    :returns: daily progress of events processing in the form required
+              by :py:func:`api.handlers.campaign_daily_progress`
+    :rtype: dict
+    """
+    return es.campaign_daily_progress(**kwargs)
+
+
 def step_stat(**kwargs):
     """ Calculate statistics for tasks by execution steps.
 

--- a/Utils/API/server/lib/dkb/api/storages/es/__init__.py
+++ b/Utils/API/server/lib/dkb/api/storages/es/__init__.py
@@ -9,5 +9,6 @@ from methods import (task_steps_hist,
                      task_chain,
                      task_kwsearch,
                      task_derivation_statistics,
+                     campaign_daily_progress,
                      campaign_stat,
                      step_stat)

--- a/Utils/API/server/lib/dkb/api/storages/es/common.py
+++ b/Utils/API/server/lib/dkb/api/storages/es/common.py
@@ -332,7 +332,8 @@ def output_formats(**kwargs):
             r['aggregations']['formats']['buckets']]
 
 
-def get_step_aggregation_query(step_type=None, selection_params={}):
+def get_step_aggregation_query(step_type=None, selection_params={},
+                               progress=False):
     """ Construct "aggs" part of ES query for steps aggregation.
 
     :raises: `ValueError`: unknown step type.
@@ -345,6 +346,9 @@ def get_step_aggregation_query(step_type=None, selection_params={}):
                              (see :py:func:`get_selection_query`)
     :type selection_params: dict
 
+    :param progress: flag parameter for progress data
+    :type progress: bool
+
     :return: "aggs" part of ES query
     :rtype: dict
     """
@@ -354,7 +358,11 @@ def get_step_aggregation_query(step_type=None, selection_params={}):
     elif step_type not in STEP_TYPES:
         raise ValueError(step_type, "Unknown step type (expected one of: %s)"
                                     % STEP_TYPES)
-    step_fields = {'step': 'step_name.keyword'}
+    step_fields = {'progress_ctag_format': 'ctag_format_step',
+                   'progress_step': 'mc_step',
+                   'step': 'step_name.keyword'}
+    if progress:
+        step_type = 'progress_' + step_type
     if step_type in step_fields:
         aggs = {'steps': {'terms': {'field': step_fields[step_type]}}}
     elif step_type == 'ctag_format':

--- a/Utils/API/server/lib/dkb/api/storages/es/common.py
+++ b/Utils/API/server/lib/dkb/api/storages/es/common.py
@@ -354,7 +354,10 @@ def get_step_aggregation_query(step_type=None, selection_params={}):
     elif step_type not in STEP_TYPES:
         raise ValueError(step_type, "Unknown step type (expected one of: %s)"
                                     % STEP_TYPES)
-    if step_type == 'ctag_format':
+    step_fields = {'step': 'step_name.keyword'}
+    if step_type in step_fields:
+        aggs = {'steps': {'terms': {'field': step_fields[step_type]}}}
+    elif step_type == 'ctag_format':
         formats = output_formats(**selection_params)
         filters = {}
         for f in formats:
@@ -366,8 +369,6 @@ def get_step_aggregation_query(step_type=None, selection_params={}):
             }
         aggs = {'steps': {'filters': {'filters': filters},
                           'aggs': {'substeps': {'terms': {'field': 'ctag'}}}}}
-    elif step_type == 'step':
-        aggs = {'steps': {'terms': {'field': 'step_name.keyword'}}}
     else:
         raise DkbApiNotImplemented("Aggregation by steps of type '%s' is not"
                                    " implemented yet.")

--- a/Utils/API/server/lib/dkb/api/storages/es/query/campaign-daily-progress-aggs
+++ b/Utils/API/server/lib/dkb/api/storages/es/query/campaign-daily-progress-aggs
@@ -1,0 +1,15 @@
+{
+  "daily_progress": {
+    "date_histogram": {
+      "field": "date",
+      "interval": "day",
+      "format": "yyyy-MM-dd",
+      "min_doc_count": 1
+    },
+    "aggs": {
+      "processed_events": {
+        "sum": {"field": "processed_events"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
[frozen]
---
*...for we not sure how to get the data we need.*

---

Add new method to API server: `campaign/daily_progress`.

The method returns data in the following format:

    {
      ...
      "data": {
        <step>: {
          <date>: <n_events_processed_by_tasks_finished_"today">,
          ...
        },
        ...
      }
    }

---

Related PR: #359