### PR TITLE
DF: allow single dataflow writing to two different ES indices.

### DIFF
--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -6,7 +6,10 @@ function exception_error_handler($errno, $errstr, $errfile, $errline ) {
 set_error_handler("exception_error_handler");
 
 # Default values.
-# ES index where the documents should be indexed/updated.
+# Alias of ES index to be used when input data does not provide one
+$DEFAULT_INDEX_ALIAS = 'tasks';
+# Name of ES index where the documents should be indexed/updated,
+# if unknown alias is used
 $DEFAULT_INDEX = 'tasks_production';
 # End-of-process marker, depending on mode.
 $EOP_DEFAULTS = Array("stream" => chr(0), "file" => "");
@@ -118,6 +121,33 @@ function getAction($row) {
   return $action;
 }
 
+function getIndex($row) {
+  /* Get destination index name for the row.
+
+  :param row: document for which the index should be determined
+  :type row: array
+
+  :return: index name
+  :rtype: str
+  */
+  global $ES_INDEX;
+  global $DEFAULT_INDEX_ALIAS;
+
+  if (isset($row['_index'])) {
+    $index_name = $row['_index'];
+  } else {
+    $index_name = $DEFAULT_INDEX_ALIAS;
+  }
+
+  if ($ES_INDEX[$index_name]) {
+    $index = $ES_INDEX[$index_name];
+  } else {
+    $index = $ES_INDEX['default'];
+  }
+
+  return $index;
+}
+
 function constructActionJson($row) {
   /* Generate a json with ES bulk API action information for a given document.
 
@@ -143,14 +173,14 @@ function constructActionJson($row) {
   :return: generated action json
   :rtype: array
   */
-  global $ES_INDEX;
   global $UPDATE_RETRIES;
 
   $act = getAction($row);
+  $index = getIndex($row);
 
   $action = Array(
     $act => Array(
-      '_index' => $ES_INDEX,
+      '_index' => $index,
       '_type'  => $row['_type'],
       '_id'    => $row['_id'],
     )
@@ -314,10 +344,11 @@ fwrite(STDERR, "(DEBUG) End-of-message marker: '" . $EOM_MARKER . "' (hex: " . $
 fwrite(STDERR, "(DEBUG) End-of-process marker: '" . $EOP_MARKER . "' (hex: " . $EOP_HEX . ").\n");
 
 
-$ES_INDEX = getenv('ES_INDEX');
-if (!$ES_INDEX) {
-  $ES_INDEX = $DEFAULT_INDEX;
-}
+$ES_INDEX = Array(
+              'tasks' => getenv('ES_INDEX_TASKS'),
+              'progress' => getenv('ES_INDEX_PROGRESS'),
+              'default' => $DEFAULT_INDEX
+            );
 
 # Process data.
 if ($h) {

--- a/Utils/Dataflow/019_esFormat/esFormat.php
+++ b/Utils/Dataflow/019_esFormat/esFormat.php
@@ -133,13 +133,13 @@ function getIndex($row) {
   global $ES_INDEX;
   global $DEFAULT_INDEX_ALIAS;
 
-  if (isset($row['_index'])) {
+  if (array_key_exists('_index', $row)) {
     $index_name = $row['_index'];
   } else {
     $index_name = $DEFAULT_INDEX_ALIAS;
   }
 
-  if ($ES_INDEX[$index_name]) {
+  if (array_key_exists($index_name, $ES_INDEX) and $ES_INDEX[$index_name]) {
     $index = $ES_INDEX[$index_name];
   } else {
     $index = $ES_INDEX['default'];

--- a/Utils/Elasticsearch/config/es.example
+++ b/Utils/Elasticsearch/config/es.example
@@ -2,4 +2,20 @@ ES_HOST=%__es_host__%           #elasticsearch host
 ES_PORT=%__es_port__%           #elasticsearch port
 ES_USER=%__es_user__%           #elasticsearch username for basic auth
 ES_PASSWORD=%__es_password__%   #password for basic auth
-ES_INDEX=tasks_production       #default index to work with; avail: tasks_production, tasks_analysis
+
+ES_INDEX_TASKS=tasks_production  #default index for tasks metadata
+                                 # avail: tasks_production, tasks_analysis
+
+ES_INDEX_PROGRESS=production_progress
+                                 #default index for tasks
+                                 # processing progress metadata
+                                 # avail: production_progress,
+                                 #        analysis_progress
+
+
+# ---
+#
+# This variable is left for backwards compatibility:
+# some stages of the `data4es` dataflow rely on it.
+# TODO: replace with ES_INDEX_TASKS everywhere
+ES_INDEX=tasks_production        #default index to work with


### PR DESCRIPTION
For now it is pretty much hardcoded: stage 019 (esFormat), that prepares data for upload, is only aware of 2 indices: "tasks" (for tasks metadata) and "progress" (for tasks processing progress metadata). If no index specified in the input data, "tasks" index is used.
There's also a "default" index -- it will be used if a desired index is not configured in the provided (or default) config file.

It may be improved later, e.g. when PHP script starts reading the configuration INI file by itself -- but for now that's enough.

ES configuration file previously contained only one index name ("ES_INDEX" variable); it is used by multiple stages so it is left in the config file to keep existing functionality. It can not be set to the
"value of ES_INDEX_TASKS" like this:

  ES_INDEX=$ES_INDEX_TASKS

Although it will be OK for shell scripts that use this file by simply sourcing it, non-shell ones have to "manually" parse it, and "$ES_INDEX_TASKS" will be considered as a plain string, not variable
value.

---

NOTE: after this PR all stages but **Stage 019** will continue to use the `ES_INDEX` parameter, while **Stage 019** will ignore it.