### PR TITLE
DF/data4es: fix issue with invalid ESC characters in JSON.

### DIFF
--- a/Utils/Dataflow/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/069_upload2es/load_data.sh
@@ -18,7 +18,7 @@ ES_CONFIG="${base_dir}/../../Elasticsearch/config/es"
 
 verify_ndjson() {
   while read -r json_line; do
-    err=`echo $json_line | jq "." 2>&1 >/dev/null`
+    err=`echo "$json_line" | jq "." 2>&1 >/dev/null`
     [ -n "$err" ] && log WARN "Failed to parse input as JSON ($err): $json_line"
   done
 }

--- a/Utils/Dataflow/run/data4es-start
+++ b/Utils/Dataflow/run/data4es-start
@@ -158,7 +158,7 @@ mediator() {
   buffer=`get_buffer "$1"`
   i=0
   while read -r line; do
-    echo $line >> $buffer
+    echo "$line" >> $buffer
     let i=$i+1
     let f=$i%$BATCH_SIZE
     [ $f -eq 0 ] && flush_buffer "$1"


### PR DESCRIPTION
If JSON contains symbols like '*', in `echo $line` they will be interpreted by Shell and turned into (e.g.) a list of local files and subdirectories. Which may contain invalid (from the JSON syntax point of view) characters/ESC sequences, like '\ '.

---

The issue had effect, for example, for tasks from production request 31979 (e.g. taskid: 21835493, 21834893).