### PR TITLE
DF/data4es/019: fix default ES config path.

### DIFF
--- a/Utils/Dataflow/data4es/019_esFormat/run.sh
+++ b/Utils/Dataflow/data4es/019_esFormat/run.sh
@@ -2,7 +2,7 @@
 
 base_dir=$(cd "$(dirname "$(readlink -f "$0")")"; pwd)
 
-ES_CONFIG=$base_dir/../../Elasticsearch/config/es
+ES_CONFIG=$base_dir/../../../Elasticsearch/config/es
 CONFIG_DEFAULT=TRUE
 
 usage() {


### PR DESCRIPTION
...that was broken after #361 (DF directory layout change).