### PR TITLE
DF/data4es(-nested)/025: change Chicago ES hosts configuration.

### DIFF
--- a/Utils/Dataflow/data4es-nested/025_chicagoES/require
+++ b/Utils/Dataflow/data4es-nested/025_chicagoES/require
@@ -1,1 +1,2 @@
 elasticsearch==6.3.0
+certifi>=2019.09.11

--- a/Utils/Dataflow/data4es-nested/025_chicagoES/stage.py
+++ b/Utils/Dataflow/data4es-nested/025_chicagoES/stage.py
@@ -47,15 +47,7 @@ finally:
 chicago_es = None
 
 chicago_hosts = [
-    {'host': '192.170.227.66', 'port': 9200},
-    {'host': '192.170.227.67', 'port': 9200},
-    {'host': '192.170.227.68', 'port': 9200},
-    {'host': '192.170.227.69', 'port': 9200},
-    {'host': '192.170.227.70', 'port': 9200},
-    {'host': '192.170.227.241', 'port': 9200},
-    {'host': '192.170.227.242', 'port': 9200},
-    {'host': '192.170.227.243', 'port': 9200},
-    {'host': '192.170.227.244', 'port': 9200}
+    {'host': 'atlas-kibana.mwt2.org', 'port': 9200, 'scheme': 'https'}
 ]
 
 META_FIELDS = {

--- a/Utils/Dataflow/data4es/025_chicagoES/require
+++ b/Utils/Dataflow/data4es/025_chicagoES/require
@@ -1,1 +1,2 @@
 elasticsearch==6.3.0
+certifi>=2019.09.11

--- a/Utils/Dataflow/data4es/025_chicagoES/stage.py
+++ b/Utils/Dataflow/data4es/025_chicagoES/stage.py
@@ -47,15 +47,7 @@ finally:
 chicago_es = None
 
 chicago_hosts = [
-    {'host': '192.170.227.66', 'port': 9200},
-    {'host': '192.170.227.67', 'port': 9200},
-    {'host': '192.170.227.68', 'port': 9200},
-    {'host': '192.170.227.69', 'port': 9200},
-    {'host': '192.170.227.70', 'port': 9200},
-    {'host': '192.170.227.241', 'port': 9200},
-    {'host': '192.170.227.242', 'port': 9200},
-    {'host': '192.170.227.243', 'port': 9200},
-    {'host': '192.170.227.244', 'port': 9200}
+    {'host': 'atlas-kibana.mwt2.org', 'port': 9200, 'scheme': 'https'}
 ]
 
 META_FIELDS = {


### PR DESCRIPTION
'atlas-kibana.mwt2.org' is the main interface host, and since recently
it uses HTTPS instead of HTTP; so we switch our stage from previous
configuration (with requests to data nodes) to the more official one.