### PR TITLE
DF/*: fix path to default ES config (again).

### DIFF
--- a/Utils/Dataflow/data4es-nested/019_esFormat/run.sh
+++ b/Utils/Dataflow/data4es-nested/019_esFormat/run.sh
@@ -2,7 +2,7 @@
 
 base_dir=$(cd "$(dirname "$(readlink -f "$0")")"; pwd)
 
-ES_CONFIG=$base_dir/../../Elasticsearch/config/es
+ES_CONFIG=$base_dir/../../../Elasticsearch/config/es
 CONFIG_DEFAULT=TRUE
 
 usage() {

--- a/Utils/Dataflow/data4es-nested/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/data4es-nested/069_upload2es/load_data.sh
@@ -12,7 +12,7 @@ PARAMETERS:
 
 base_dir=$( cd "$( dirname "$( readlink -f "$0" )" )" && pwd )
 
-ES_CONFIG="${base_dir}/../../Elasticsearch/config/es"
+ES_CONFIG="${base_dir}/../../../Elasticsearch/config/es"
 
 . "$base_dir"/../shell_lib/log
 

--- a/Utils/Dataflow/data4es-nested/run/data4es-consistency-check
+++ b/Utils/Dataflow/data4es-nested/run/data4es-consistency-check
@@ -8,7 +8,7 @@ lib="$base_dir/../shell_lib"
 # Directories with configuration files
 [ -n "$DATA4ES_CONSISTENCY_CONFIG_PATH" ] && \
     CONFIG_PATH="$DATA4ES_CONSISTENCY_CONFIG_PATH" || \
-    CONFIG_PATH="${base_dir}/../config:${base_dir}/../../Elasticsearch/config"
+    CONFIG_PATH="${base_dir}/../config:${base_dir}/../../../Elasticsearch/config"
 
 source $lib/get_config
 source $lib/eop_filter

--- a/Utils/Dataflow/data4es/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/data4es/069_upload2es/load_data.sh
@@ -12,7 +12,7 @@ PARAMETERS:
 
 base_dir=$( cd "$( dirname "$( readlink -f "$0" )" )" && pwd )
 
-ES_CONFIG="${base_dir}/../../Elasticsearch/config/es"
+ES_CONFIG="${base_dir}/../../../Elasticsearch/config/es"
 
 . "$base_dir"/../shell_lib/log
 

--- a/Utils/Dataflow/data4es/run/data4es-consistency-check
+++ b/Utils/Dataflow/data4es/run/data4es-consistency-check
@@ -8,7 +8,7 @@ lib="$base_dir/../shell_lib"
 # Directories with configuration files
 [ -n "$DATA4ES_CONSISTENCY_CONFIG_PATH" ] && \
     CONFIG_PATH="$DATA4ES_CONSISTENCY_CONFIG_PATH" || \
-    CONFIG_PATH="${base_dir}/../config:${base_dir}/../../Elasticsearch/config"
+    CONFIG_PATH="${base_dir}/../config:${base_dir}/../../../Elasticsearch/config"
 
 source $lib/get_config
 source $lib/eop_filter


### PR DESCRIPTION
The path was broken in 70bb8e9 and was only fixed in a couple of places
instead of all the affected files.