### PR TITLE
DF/run_stage: add stage ID as prefix to stage's stderr lines.

### DIFF
--- a/Utils/Dataflow/shell_lib/run_stage
+++ b/Utils/Dataflow/shell_lib/run_stage
@@ -18,7 +18,9 @@ run_stage() {
   # | 1 \
   # | 2
   tee $inp \
-    | ${!cmd} \
+    | ${!cmd} 2> >(while read line; do
+                     echo -e "($1) $line" >&2
+                   done) \
     | tee $out
 
   # return the command execution status, not `tee`'s


### PR DESCRIPTION
Each STDERR line is now prefixed with source stage's ID:

    (ID) <original stderr line>

Example of log after this PR:
```
(INFO) 28-08-2020 13:50:09 (data4es) Stage 19 set to update mode.
(INFO) 28-08-2020 13:50:09 (data4es) Starting process.
(17) 2020-08-28 13:50:09 (WARN) (pyDKB.dataflow.cds) Submodule failed (No module named invenio_client.contrib)
(09) (INFO) Stage 009 configuration (/home/dkb/dkb-dev.git/Utils/Dataflow/data4es/config/009.cfg):
(09) (INFO) ---
(09) (INFO)  step_seconds : '86400'
(09) (INFO)  initial_date : '2020-08-27 11:00:00'
(09) (INFO)  timestamp_tz : 'UTC'
(09) (INFO)  offset_file  : '/home/dkb/dkb-dev.git/Utils/Dataflow/data4es/config/.offset'
(09) (INFO)  delay        : '0'
(09) (INFO)  mode         : 'SQUASH'
(09) (INFO)  queries      : '{'tasks': {'params': {'production_or_analysis_cond': '>'}, 'file': '/home/dkb/dkb-dev.git/Utils/Dataflow/data4es/run/../009_oracleConnector/query/data4es/tasks'}, 'datasets': {'params': {'production_or_analysis_cond': '>'}, 'file': '/home/dkb/dkb-dev.git/Utils/Dataflow/data4es/run/../009_oracleConnector/query/data4es/datasets'}}'
(09) (INFO)  final_date   : '2020-08-27 11:10:00'
(09) (INFO) ---
(09) (INFO) Establish connection to the DB...
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage) Configuration parameters:
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   hdfs         : 'False'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   dest         : 's'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   input_dir    : 'None'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   skip_process : 'False'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   eom          : 'n'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   output_dir   : 'out'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   source       : 's'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   eop          : '
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   mode         : 's'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   config       : 'None'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage)   input_files  : '[]'
(17) 2020-08-28 13:50:09 (INFO) (ProcessorStage) Starting stage execution.
(93) 2020-08-28 13:50:09 (WARN) (pyDKB.dataflow.cds) Submodule failed (No module named invenio_client.contrib)
(40) 2020-08-28 13:50:09 (WARN) (pyDKB.dataflow.cds) Submodule failed (No module named invenio_client.contrib)
(19) (DEBUG) End-of-message marker: '^^' (hex: 1e).
(19) (DEBUG) End-of-process marker: '
(16) 2020-08-28 13:50:09 (WARN) (pyDKB.dataflow.cds) Submodule failed (No module named invenio_client.contrib)
(19) (DEBUG) End-of-message marker: '^^' (hex: 1e).
(19) (DEBUG) End-of-process marker: '
(91_in) (ERROR) Could not load rucio configuration file rucio.cfg.Rucio looks in the following directories for a configuration file, in order:
(91_in) ${RUCIO_HOME}/etc/rucio.cfg
(91_in) /opt/rucio/etc/rucio.cfg
(91_in) ${VIRTUAL_ENV}/etc/rucio.cfg.
```