### PR TITLE
DF/data4es(-nested)/025: fix indices names definition.

### DIFF
--- a/Utils/Dataflow/data4es-nested/025_chicagoES/stage.py
+++ b/Utils/Dataflow/data4es-nested/025_chicagoES/stage.py
@@ -201,9 +201,10 @@ def get_indices_by_interval(start_time, end_time, index='jobs',
     end = end_time.date()
     cur = beg
     result = []
-    while cur <= end + delta - datetime.timedelta(days=1):
+    while cur < end:
         result += [prefix + cur.strftime(d_format) + '*' * wildcard]
         cur += delta
+    result += [prefix + end.strftime(d_format) + '*' * wildcard]
     return list(set(result))
 
 

--- a/Utils/Dataflow/data4es/025_chicagoES/stage.py
+++ b/Utils/Dataflow/data4es/025_chicagoES/stage.py
@@ -201,9 +201,10 @@ def get_indices_by_interval(start_time, end_time, index='jobs',
     end = end_time.date()
     cur = beg
     result = []
-    while cur <= end + delta - datetime.timedelta(days=1):
+    while cur < end:
         result += [prefix + cur.strftime(d_format) + '*' * wildcard]
         cur += delta
+    result += [prefix + end.strftime(d_format) + '*' * wildcard]
     return list(set(result))
 
 


### PR DESCRIPTION
The logic about how to get the list of indices was a bit wierd.

Now it is as follows:
* list of indices is combined from index names generated for set of  time points;
* index name is prefix + datetime suffix, taken at given time point;
* set of time points is from task's beginnig till the tasks's end with step matching (shortest) interval between two successive index names:
  * 1 day (eg for '*_2020-01-24' and '*_2020-01-25');
  * 28 days (eg for '*_2020-02*' and '*_2020-03*');
  * 365 days (eg for '*_2019' and '*_2020');
* task's end is always used to produce one more index name (so it does not matter if the last time point was in the same index or in the previous one -- it will be added anyway).

This way all indices starting from the one containing task's beginning to the one containing task's end are added to the list.