### PR TITLE
DF/data4es(-nested)/017: fix issue with NULL value of "output_formats".

### DIFF
--- a/Utils/Dataflow/data4es-nested/017_adjustMetadata/adjustMetadata.py
+++ b/Utils/Dataflow/data4es-nested/017_adjustMetadata/adjustMetadata.py
@@ -333,7 +333,9 @@ def generate_step_names(data):
     """
     ignore_formats = ['LOG']
     output_formats = data.get('output_formats', [])
-    if not isinstance(output_formats, list):
+    if not output_formats:
+        output_formats = []
+    elif not isinstance(output_formats, list):
         output_formats = [output_formats]
     ctag = data.get('ctag')
     tags = data.get('ami_tags')

--- a/Utils/Dataflow/data4es/017_adjustMetadata/adjustMetadata.py
+++ b/Utils/Dataflow/data4es/017_adjustMetadata/adjustMetadata.py
@@ -333,7 +333,9 @@ def generate_step_names(data):
     """
     ignore_formats = ['LOG']
     output_formats = data.get('output_formats', [])
-    if not isinstance(output_formats, list):
+    if not output_formats:
+        output_formats = []
+    elif not isinstance(output_formats, list):
         output_formats = [output_formats]
     ctag = data.get('ctag')
     tags = data.get('ami_tags')


### PR DESCRIPTION
Explicitly specified NULL value led to the following error in the DF process:

```
(17) 2020-09-13 05:06:10 (ERROR) (ProcessorStage) sequence item 1: expected string or Unicode, NoneType found
(17) 2020-09-13 05:06:10 (DEBUG) (ProcessorStage) Traceback (most recent call last):
(17) (==)   File <...>, line 399, in process
(17) (==)     generate_step_names(data)
(17) (==)   File <...>, line 348, in generate_step_names
(17) (==)     data['ami_tags_format_step'].append(':'.join([tags, data_format]))
(17) (==) TypeError: sequence item 1: expected string or Unicode, NoneType found
```