### PR TITLE
DF/data4es(-nested)/095: retry 'ListCommands' on client initialisation.

### DIFF
--- a/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
@@ -112,7 +112,9 @@ def init_ami_client(userkey='', usercert=''):
                      " that AMI client works and the credentials are"
                      " correct...\n")
     try:
-        ami_client.execute('ListCommands')
+        execute_with_retry(ami_client.execute, args=['ListCommands'],
+                           retry_on=(AMIError, http_client.HTTPException),
+                           sleep=64)
     except Exception as e:
         sys.stderr.write("(ERROR) Test command ListCommands failed. Are you"
                          " sure you have a valid certificate?\n"

--- a/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
@@ -112,7 +112,9 @@ def init_ami_client(userkey='', usercert=''):
                      " that AMI client works and the credentials are"
                      " correct...\n")
     try:
-        ami_client.execute('ListCommands')
+        execute_with_retry(ami_client.execute, args=['ListCommands'],
+                           retry_on=(AMIError, http_client.HTTPException),
+                           sleep=64)
     except Exception as e:
         sys.stderr.write("(ERROR) Test command ListCommands failed. Are you"
                          " sure you have a valid certificate?\n"


### PR DESCRIPTION
Without this retry the stage fails sometimes like this:

    (ERROR) Test command ListCommands failed. Are you sure you have a
    valid certificate?
    (==) Exception: pyAMI exception: could not connect to
    `https://ami.in2p3.fr:443/AMI/servlet/net.hep.atlas.Database.Bookkeeping.AMI.Servlet.FrontEnd`:
    [Errno 111] Connection refused

It seems to happen due to some issues at the AMI server side, but those are usually short-time ones, so a retry after a while is very likely to be successful.