### PR TITLE
DF/data4es(-nested)/095: use CERN instance of AMI.

### DIFF
--- a/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
@@ -90,8 +90,8 @@ def init_ami_client(userkey='', usercert=''):
     """
     global ami_client
     try:
-        ami_client = pyAMI.client.Client('atlas', key_file=userkey,
-                                         cert_file=usercert)
+        ami_client = pyAMI.client.Client(['atlas-replica', 'atlas'],
+                                         key_file=userkey, cert_file=usercert)
         AtlasAPI.init()
     except NameError:
         sys.stderr.write("(FATAL) Failed to initialise AMI client:"

--- a/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
@@ -90,8 +90,8 @@ def init_ami_client(userkey='', usercert=''):
     """
     global ami_client
     try:
-        ami_client = pyAMI.client.Client('atlas', key_file=userkey,
-                                         cert_file=usercert)
+        ami_client = pyAMI.client.Client(['atlas-replica', 'atlas'],
+                                         key_file=userkey, cert_file=usercert)
         AtlasAPI.init()
     except NameError:
         sys.stderr.write("(FATAL) Failed to initialise AMI client:"


### PR DESCRIPTION
Endpoints (see `pyAMI/atlas/__init__.py`):
  - 'atlas': 'https://ami.in2p3.fr:443/AMI/servlet/net.hep.atlas.Database.Bookkeeping.AMI.Servlet.FrontEnd'
  - 'atlas-replica': 'https://atlas-ami.cern.ch:443/AMI/servlet/net.hep.atlas.Database.Bookkeeping.AMI.Servlet.FrontEnd'

It is said that CERN replica is less loaded while have same data.
Endpoints passed to `pyAMI.client.Client()` are used one after another in `execute()` until succsess, so after this change client will first query the CERN instance and then, in case of any problem, fall back to the main 'atlas' instance in France.