### PR TITLE
DF/data4es-nested/091: bug fix.

### DIFF
--- a/Utils/Dataflow/data4es-nested/091_datasetsRucio/datasets_processing.py
+++ b/Utils/Dataflow/data4es-nested/091_datasetsRucio/datasets_processing.py
@@ -77,6 +77,9 @@ def main(argv):
     stage.set_input_message_type(messageType.JSON)
     stage.set_output_message_type(messageType.JSON)
 
+    global log
+    log = stage.log
+
     stage.configure(argv)
     stage.process = process
     exit_code = stage.run()
@@ -209,10 +212,10 @@ def process_ds(datasets, ds_type):
         try:
             ds = get_ds_info(ds_name, mfields)
         except RucioException, err:
-            stage.log(["Failed to get information"
-                       " from Rucio for: %s." % ds_name,
-                       "Reason: %s." % str(err)],
-                      logLevel.WARN)
+            log(["Failed to get information"
+                 " from Rucio for: %s." % ds_name,
+                 "Reason: %s." % str(err)],
+                logLevel.WARN)
             status = False
             ds = {}
         if ds_type == OUTPUT:


### PR DESCRIPTION
`stage.log` used in a function where `stage` isn't defined.

Fixes issue:
```
(91) 2020-10-02 03:50:28 (ERROR) (ProcessorStage) global name 'stage' is not defined
(91) 2020-10-02 03:50:28 (DEBUG) (ProcessorStage) Traceback (most recent call last):
(91) (==)   File "/home/dkb/dkb-test.git/Utils/Dataflow/data4es-nested/091_datasetsRucio/../pyDKB/dataflow/stage/ProcessorStage.py", line 255, in run
(91) (==)     if msg and process(self, msg):
(91) (==)   File "/home/dkb/dkb-test.git/Utils/Dataflow/data4es-nested/run/../091_datasetsRucio/datasets_processing.py", line 162, in process
(91) (==)     output_ds = process_ds(data.get(SRC_FIELD[OUTPUT]), OUTPUT)
(91) (==)   File "/home/dkb/dkb-test.git/Utils/Dataflow/data4es-nested/run/../091_datasetsRucio/datasets_processing.py", line 212, in process_ds
(91) (==)     stage.log(["Failed to get information"
(91) (==) NameError: global name 'stage' is not defined
(91) 2020-10-02 03:50:28 (INFO) (ProcessorStage) Stopping stage.
```