### PR TITLE
API: nested warning.

### DIFF
--- a/Utils/API/server/lib/dkb/api/__init__.py
+++ b/Utils/API/server/lib/dkb/api/__init__.py
@@ -10,7 +10,7 @@ import methods
 CONFIG_DIR = '%%CFG_DIR%%'
 
 
-__version__ = '0.3.0-dev20201005'
+__version__ = '0.3.0-dev20201006a'
 
 
 STATUS_CODES = {

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -83,13 +83,12 @@ def nested(path, **kwargs):
     if not path.startswith('/nested/'):
         raise MethodException("Method handler 'nested' is called for"
                               " non-'nested' method path: '%s'" % path)
-    default_handler_path = path.replace('/nested', '', 1)
+    default_path = path.replace('/nested', '', 1)
 
     # Marker for alternative method's implementation usage
     kwargs['_alt'] = 'nested'
 
-    return methods.handler(default_handler_path)(default_handler_path,
-                                                 **kwargs)
+    return methods.handler(default_path)(default_path, **kwargs)
 
 
 methods.add('/nested', '.*', nested)

--- a/Utils/API/server/lib/dkb/api/handlers.py
+++ b/Utils/API/server/lib/dkb/api/handlers.py
@@ -88,7 +88,19 @@ def nested(path, **kwargs):
     # Marker for alternative method's implementation usage
     kwargs['_alt'] = 'nested'
 
-    return methods.handler(default_path)(default_path, **kwargs)
+    data, metadata = methods.handler(default_path)(default_path, **kwargs)
+
+    warn = 'Completeness of data in the response is not guaranteed' \
+           ' (used ES indices can contain incomplete set of metadata).'
+
+    if 'warning' not in metadata:
+        metadata['warning'] = warn
+    elif type(metadata['warning']) is list:
+        metadata['warning'].append(warn)
+    else:
+        metadata['warning'] = [metadata['warning'], warn]
+
+    return data, metadata
 
 
 methods.add('/nested', '.*', nested)


### PR DESCRIPTION
Minor changes:
* nested endpoint methods' results are accompanied with a warning
  message regarding incompleteness of data in ES indices.

---

NOTE: the warning appears in any method's response, even if it is `/info` method that has nothing to do with ES indices. But I guess it's fine: better to be warned before using any of the methods listed in the `/info` response...