### PR TITLE
DF/data4es(-nested)/095: improve try/except logic.

### DIFF
--- a/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
@@ -163,10 +163,11 @@ def process(stage, message):
             except Exception:
                 stage.output_error("Failed to process dataset '%s'"
                                    % ds['name'], sys.exc_info())
-            # Do not put this into try/except above:
-            #   any exception produced by it indicates a problem
-            #   with the stage code that demands a full stop.
-            change_key_names(ds)
+            else:
+                # Do not put this into try/except above:
+                #   any exception produced by it indicates a problem
+                #   with the stage code that demands a full stop.
+                change_key_names(ds)
     stage.output(pyDKB.dataflow.communication.messages.JSONMessage(data))
 
     return True

--- a/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
@@ -170,9 +170,11 @@ def process(stage, message):
         except Exception:
             stage.output_error("Failed to process dataset '%s'"
                                % data['datasetname'], sys.exc_info())
-        # Do not put this into try/except above - any exception produced by it
-        # indicates a problem with the stage code that demands a full stop.
-        change_key_names(data)
+        else:
+            # Do not put this into try/except above - any exception produced
+            # by it indicates a problem with the stage code that demands
+            # a full stop.
+            change_key_names(data)
     stage.output(pyDKB.dataflow.communication.messages.JSONMessage(data))
 
     return True


### PR DESCRIPTION
The operation `change_key_names()` makes no sence in case when there was
any exception; so placing it after `try/except` clause just "as is"
looks a bit wierd.

Placing it into `else` section of `try/except` says: "and if
everything's fine we need to do this thing". This looks better.