### PR TITLE
DF/data4es(-nested)/095: improve invalid AMI response handling.

### DIFF
--- a/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
@@ -195,9 +195,11 @@ def amiPhysValues(data):
                    'format': 'json'}
     res = execute_with_retry(ami_client.execute, kwargs=exec_params, sleep=64,
                              retry_on=(AMIError, http_client.HTTPException))
-    json_str = json.loads(res)
     try:
+        json_str = json.loads(res)
         rowset = json_str['AMIMessage'][0]['Result'][0]['rowset']
+    except ValueError:
+        raise Exception("Non-JSON AMI response: %s" % res)
     except Exception:
         raise Exception("Unexpected AMI response: %s" % json_str)
     if not rowset:

--- a/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es/095_datasetInfoAMI/amiDatasets.py
@@ -202,9 +202,11 @@ def amiPhysValues(data):
                    'format': 'json'}
     res = execute_with_retry(ami_client.execute, kwargs=exec_params, sleep=64,
                              retry_on=(AMIError, http_client.HTTPException))
-    json_str = json.loads(res)
     try:
+        json_str = json.loads(res)
         rowset = json_str['AMIMessage'][0]['Result'][0]['rowset']
+    except ValueError:
+        raise Exception("Non-JSON AMI response: %s" % res)
     except Exception:
         raise Exception("Unexpected AMI response: %s" % json_str)
     if not rowset:


### PR DESCRIPTION
Sometimes AMI response is not a JSON object, and stage fails to parse it as JSON:
```
(95) 2020-11-22 22:10:24 (DEBUG) (ProcessorStage) Traceback (most recent call last):
(95) (==)   File "/home/dkb/dkb-test.git/Utils/Dataflow/data4es/run/../095_datasetInfoAMI/amiDatasets.py", line 167, in process
(95) (==)     amiPhysValues(data)
(95) (==)   File "/home/dkb/dkb-test.git/Utils/Dataflow/data4es/run/../095_datasetInfoAMI/amiDatasets.py", line 203, in amiPhysValues
(95) (==)     json_str = json.loads(res)
(95) (==)   File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
(95) (==)     return _default_decoder.decode(s)
(95) (==)   File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
(95) (==)     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
(95) (==)   File "/usr/lib64/python2.7/json/decoder.py", line 384, in raw_decode
(95) (==)     raise ValueError("No JSON object could be decoded")
(95) (==) ValueError: No JSON object could be decoded
```

It is not very informative; so now it's gonna output the response, kind of this:
```
2020-11-26 11:34:52 (DEBUG) (ProcessorStage) Traceback (most recent call last):
(==)   File "./amiDatasets.py", line 167, in process
(==)     amiPhysValues(data)
(==)   File "./amiDatasets.py", line 208, in amiPhysValues
(==)     raise Exception("Non-JSON AMI response: %s" % res)
(==) Exception: Non-JSON AMI response: AMI#
(==) command : AMIGetPhysicsParamsForDataset
(==) time    : 2020-11-26  at 11:34:51 AM CET
(==) result  :
(==)   -> rowset
(==)     -> row 1
(==)       -> logicalDatasetName = mc16_13TeV.395366.MGPy8EG_A14N23LO_CC_directZlHlWv_550.recon.AOD.e6715_e5984_a875_r10201
(==)       -> end_time =
(==)       -> insert_time = 2018-10-16 22:09:51
<...>
```