### PR TITLE
DF: improve AMI error logging

### DIFF
--- a/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
@@ -22,6 +22,7 @@ try:
     from pyDKB.dataflow.exceptions import DataflowException
     from pyDKB import atlas
     from pyDKB.common.misc import execute_with_retry
+    from pyDKB.common.types import logLevel
 except Exception, err:
     sys.stderr.write("(ERROR) Failed to import pyDKB library: %s\n" % err)
     sys.exit(1)
@@ -160,9 +161,10 @@ def process(stage, message):
                 amiPhysValues(ds)
             except DataflowException:
                 raise
-            except Exception:
-                stage.output_error("Failed to process dataset '%s'"
-                                   % ds['name'], sys.exc_info())
+            except Exception, err:
+                stage.log(["Failed to process dataset '%s'" % ds['name'],
+                           "Reason: %s" % err],
+                          logLevel.WARN)
             else:
                 # Do not put this into try/except above:
                 #   any exception produced by it indicates a problem
@@ -199,9 +201,9 @@ def amiPhysValues(data):
         json_str = json.loads(res)
         rowset = json_str['AMIMessage'][0]['Result'][0]['rowset']
     except ValueError:
-        raise Exception("Non-JSON AMI response: %s" % res)
+        raise Exception("Non-JSON AMI response: %r" % res)
     except Exception:
-        raise Exception("Unexpected AMI response: %s" % json_str)
+        raise Exception("Unexpected AMI response: %r" % json_str)
     if not rowset:
         sys.stderr.write("(WARN) No values found in AMI for dataset '%s'\n"
                          % data['name'])

--- a/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
+++ b/Utils/Dataflow/data4es-nested/095_datasetInfoAMI/amiDatasets.py
@@ -205,9 +205,7 @@ def amiPhysValues(data):
     except Exception:
         raise Exception("Unexpected AMI response: %r" % json_str)
     if not rowset:
-        sys.stderr.write("(WARN) No values found in AMI for dataset '%s'\n"
-                         % data['name'])
-        return False
+        raise Exception("No values found in AMI")
     for row in rowset[0]['row']:
         p_name, p_val = None, None
         for field in row['field']:


### PR DESCRIPTION
Any error occured when the stage tries to get additional metadata from AMI is not a critical error; so it's better to be output as 'WARN', not 'ERROR'+traceback.

Currently log messages look like these
```
2021-03-19 14:26:07 (WARN) (ProcessorStage) Failed to process dataset 'mc16_13TeV.346806.MadGraphPythia8EvtGen_A14NNPDF23LO_RS_G_ZZ_llll_c10_m0200.simul.HITS.e7972_e5984_s3126_tid20330292_0
0'
(==) Reason: Non-JSON AMI response: u'AMI#\ncommand : AMIGetPhysicsParamsForDataset\ntime    : 2021-03-19  at 02:26:07 PM CET\nresult  : \n  -> rowset\n#'
```

```
2021-03-19 14:25:48 (WARN) (ProcessorStage) Failed to process dataset 'mc16_13TeV.346806.MadGraphPythia8EvtGen_A14NNPDF23LO_RS_G_ZZ_llll_c10_m0200.simul.HITS.e7972_e5984_s3126_tid20330292_0
0'
(==) Reason: Unexpected AMI response: {u'AMIMessage': [{u'executionTime': [{u'$': u'0.0'}], u'error': [{u'$': u'Command not found `AMIGetPhysicsParamsForDatasett`.'}]}]}
```

```
2021-03-19 14:25:31 (WARN) (ProcessorStage) Failed to process dataset 'mc16_13TeV.346806.MadGraphPythia8EvtGen_A14NNPDF23LO_RS_G_ZZ_llll_c10_m0200.simul.HITS.e7972_e5984_s3126_tid20330292_0
0'
(==) Reason: No values found in AMI
```

---
Fixes #434