### PR TITLE
fix(DF/config): pass proper config file to stage 025

### DIFF
--- a/Utils/Dataflow/data4es-nested/run/data4es-start
+++ b/Utils/Dataflow/data4es-nested/run/data4es-start
@@ -87,7 +87,8 @@ define_stages() {
   cmd_09="$cmd_09 --config $cfg_09"
 
   # Stage 25
-  cmd_25="${base_dir}/../025_chicagoES/stage.py -m s"
+  cfg_25=`get_config "025.cfg"`
+  cmd_25="${base_dir}/../025_chicagoES/stage.py -m s --config $cfg_25"
 
   # Stage 16
   cmd_16="${base_dir}/../016_task2es/task2es.py -m s"


### PR DESCRIPTION
`data4es-start` wouldn't pass to stage 025 (Chicago ES) path to the
config file from the common config directory; insted, the stage used the
default config file from `025_chicagoES/../config/025.cfg`.