### PR TITLE
feat(config): more ES access params

### DIFF
--- a/Utils/Dataflow/data4es/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/data4es/069_upload2es/load_data.sh
@@ -74,17 +74,19 @@ done
 log "Loading defaults and config $ES_CONFIG if any"
 ES_HOST='127.0.0.1'
 ES_PORT='9200'
+ES_PATH=''
 ES_PROTO='http'
 
 [ -f "$ES_CONFIG" ] && source "$ES_CONFIG"
 [ -n "$ES_USER" -a "$ES_PASSWORD" ] && ES_AUTH="--user ${ES_USER}:${ES_PASSWORD}"
+[ "$ES_PATH" == '/' ] && ES_PATH=''
 
 CURL_N_MAX=10
 SLEEP=5
 DELIMITER=`echo -e -n "\x00"`
 EOProcess=`echo -e -n "\x06"`
 
-cmd="curl -sS $ES_AUTH $ES_PROTO://$ES_HOST:$ES_PORT/_bulk?pretty --data-binary @"
+cmd="curl -sS $ES_AUTH $ES_PROTO://$ES_HOST:${ES_PORT}${ES_PATH}/_bulk?pretty --data-binary @"
 
 load_files () {
   [ -z "$1" -o ! -f "$1" ] && log $(usage) && exit 1

--- a/Utils/Dataflow/data4es/069_upload2es/load_data.sh
+++ b/Utils/Dataflow/data4es/069_upload2es/load_data.sh
@@ -74,6 +74,7 @@ done
 log "Loading defaults and config $ES_CONFIG if any"
 ES_HOST='127.0.0.1'
 ES_PORT='9200'
+ES_PROTO='http'
 
 [ -f "$ES_CONFIG" ] && source "$ES_CONFIG"
 [ -n "$ES_USER" -a "$ES_PASSWORD" ] && ES_AUTH="--user ${ES_USER}:${ES_PASSWORD}"
@@ -83,7 +84,7 @@ SLEEP=5
 DELIMITER=`echo -e -n "\x00"`
 EOProcess=`echo -e -n "\x06"`
 
-cmd="curl -sS $ES_AUTH http://$ES_HOST:$ES_PORT/_bulk?pretty --data-binary @"
+cmd="curl -sS $ES_AUTH $ES_PROTO://$ES_HOST:$ES_PORT/_bulk?pretty --data-binary @"
 
 load_files () {
   [ -z "$1" -o ! -f "$1" ] && log $(usage) && exit 1

--- a/Utils/Dataflow/data4es/071_esConsistency/consistency.py
+++ b/Utils/Dataflow/data4es/071_esConsistency/consistency.py
@@ -54,8 +54,10 @@ def load_config(fname):
     :type fname: str
     '''
     cfg = {
+        'ES_PROTO': 'http',
         'ES_HOST': '',
         'ES_PORT': '',
+        'ES_PATH': '',
         'ES_USER': '',
         'ES_PASSWORD': '',
         'ES_INDEX': ''
@@ -95,9 +97,11 @@ def es_connect(cfg):
     global es
     s = '%s:%s' % (cfg['ES_HOST'], cfg['ES_PORT'])
     if cfg['ES_USER'] and cfg['ES_PASSWORD']:
-        s = 'http://%s:%s@%s/' % (cfg['ES_USER'],
-                                  cfg['ES_PASSWORD'],
-                                  s)
+        s = '%s://%s:%s@%s/%s/' % (cfg['ES_PROTO'],
+                                   cfg['ES_USER'],
+                                   cfg['ES_PASSWORD'],
+                                   s,
+                                   cfg['ES_PATH'])
     es = elasticsearch.Elasticsearch([s])
     return True
 

--- a/Utils/Dataflow/data4es/071_esConsistency/consistency.py
+++ b/Utils/Dataflow/data4es/071_esConsistency/consistency.py
@@ -60,6 +60,7 @@ def load_config(fname):
         'ES_PATH': '',
         'ES_USER': '',
         'ES_PASSWORD': '',
+        'ES_CA_CERTS': '/etc/pki/tls/certs/CERN-bundle.pem',
         'ES_INDEX': ''
     }
     with open(fname) as f:
@@ -102,7 +103,10 @@ def es_connect(cfg):
                                    cfg['ES_PASSWORD'],
                                    s,
                                    cfg['ES_PATH'])
-    es = elasticsearch.Elasticsearch([s])
+
+    ca_certs = cfg['ES_CA_CERTS'] if cfg['ES_PROTO'] == 'https' else None
+
+    es = elasticsearch.Elasticsearch([s], ca_certs=ca_certs)
     return True
 
 

--- a/Utils/Elasticsearch/config/es.example
+++ b/Utils/Elasticsearch/config/es.example
@@ -4,6 +4,7 @@ ES_PATH=%__es_path__%           #path to ES entry point (e.g. '/' (default), '/e
 ES_PROTO=%__es_proto__%         #protocol (http,https)
 ES_USER=%__es_user__%           #elasticsearch username for basic auth
 ES_PASSWORD=%__es_password__%   #password for basic auth
+ES_CA_CERTS=%__es_ca_certs__%   #path to CA certs
 
 ES_INDEX_TASKS=tasks_production  #default index for tasks metadata
                                  # avail: tasks_production, tasks_analysis

--- a/Utils/Elasticsearch/config/es.example
+++ b/Utils/Elasticsearch/config/es.example
@@ -1,5 +1,6 @@
 ES_HOST=%__es_host__%           #elasticsearch host
 ES_PORT=%__es_port__%           #elasticsearch port
+ES_PATH=%__es_path__%           #path to ES entry point (e.g. '/' (default), '/es', etc)
 ES_USER=%__es_user__%           #elasticsearch username for basic auth
 ES_PASSWORD=%__es_password__%   #password for basic auth
 

--- a/Utils/Elasticsearch/config/es.example
+++ b/Utils/Elasticsearch/config/es.example
@@ -1,6 +1,7 @@
 ES_HOST=%__es_host__%           #elasticsearch host
 ES_PORT=%__es_port__%           #elasticsearch port
 ES_PATH=%__es_path__%           #path to ES entry point (e.g. '/' (default), '/es', etc)
+ES_PROTO=%__es_proto__%         #protocol (http,https)
 ES_USER=%__es_user__%           #elasticsearch username for basic auth
 ES_PASSWORD=%__es_password__%   #password for basic auth
 

--- a/Utils/Elasticsearch/tools/load_mapping.sh
+++ b/Utils/Elasticsearch/tools/load_mapping.sh
@@ -11,6 +11,7 @@ ES_CONFIG="$(dirname $0)/../config/es"
 ES_HOST='127.0.0.1'
 ES_PORT='9200'
 ES_PATH=''
+ES_PROTO='http'
 
 while getopts c: opt; do
   case $opt in		
@@ -28,4 +29,4 @@ shift $((OPTIND-1))
   && echo "You must provide path to mapping file!" \
   || curl $ES_AUTH -H "Content-Type: application/x-ndjson" \
           -XPUT --data-binary "@${1}" \
-          "http://${ES_HOST}:${ES_PORT}${ES_PATH}/_template/`basename ${1%.*}`?pretty"
+          "${ES_PROTO}://${ES_HOST}:${ES_PORT}${ES_PATH}/_template/`basename ${1%.*}`?pretty"

--- a/Utils/Elasticsearch/tools/load_mapping.sh
+++ b/Utils/Elasticsearch/tools/load_mapping.sh
@@ -10,6 +10,7 @@ EOF
 ES_CONFIG="$(dirname $0)/../config/es"
 ES_HOST='127.0.0.1'
 ES_PORT='9200'
+ES_PATH=''
 
 while getopts c: opt; do
   case $opt in		
@@ -21,8 +22,10 @@ done
 [ -n "$ES_USER" -a "$ES_PASSWORD" ] && ES_AUTH="--user ${ES_USER}:${ES_PASSWORD}"
 shift $((OPTIND-1)) 
 
+[ "$ES_PATH" == '/' ] && ES_PATH=''
+
 [ -z "$1" -o ! -f "${1}" ] \
   && echo "You must provide path to mapping file!" \
   || curl $ES_AUTH -H "Content-Type: application/x-ndjson" \
           -XPUT --data-binary "@${1}" \
-          "http://${ES_HOST}:${ES_PORT}/_template/`basename ${1%.*}`?pretty"
+          "http://${ES_HOST}:${ES_PORT}${ES_PATH}/_template/`basename ${1%.*}`?pretty"

--- a/Utils/Elasticsearch/tools/search.sh
+++ b/Utils/Elasticsearch/tools/search.sh
@@ -2,7 +2,8 @@
 ES_HOST='localhost'
 ES_PORT=9200
 ES_PATH=''
+ES_PROTO='http'
 [ -f "config/es" ] && source "config/es"
 [ -n "$ES_USER" -a -n "$ES_PASSWORD" ] && AUTH="-u $ES_USER:$ES_PASSWORD"
 [ "$ES_PATH" == '/' ] && ES_PATH=''
-curl $AUTH -H "Content-Type: application/x-ndjson" -XPOST "http://$ES_HOST:${ES_PORT}${ES_PATH}/prodsys/_search?pretty" --data-binary "@$1"
+curl $AUTH -H "Content-Type: application/x-ndjson" -XPOST "${ES_PROTO}://$ES_HOST:${ES_PORT}${ES_PATH}/prodsys/_search?pretty" --data-binary "@$1"

--- a/Utils/Elasticsearch/tools/search.sh
+++ b/Utils/Elasticsearch/tools/search.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 ES_HOST='localhost'
 ES_PORT=9200
+ES_PATH=''
 [ -f "config/es" ] && source "config/es"
 [ -n "$ES_USER" -a -n "$ES_PASSWORD" ] && AUTH="-u $ES_USER:$ES_PASSWORD"
-curl $AUTH -H "Content-Type: application/x-ndjson" -XPOST "http://$ES_HOST:$ES_PORT/prodsys/_search?pretty" --data-binary "@$1"
+[ "$ES_PATH" == '/' ] && ES_PATH=''
+curl $AUTH -H "Content-Type: application/x-ndjson" -XPOST "http://$ES_HOST:${ES_PORT}${ES_PATH}/prodsys/_search?pretty" --data-binary "@$1"


### PR DESCRIPTION
Add ES config parameters:
- `ES_PATH` (to allow endpoints like `host:port/path`, not only `host:port/`);
- `ES_PROTO` (to allow not only HTTP, but also HTTPS (or whatever specified) protocol for ES connections);
- `ES_CA_CERTS` (for Python client in consistency check only; `curl` seem to find path to certs by itself, so the usage of parametric value is not required right now).

Affected:
- `Utils/Elasticsearch/tools` (`load_mapping` and `search`);
- `Utils/Dataflow/data4es/069_upload2es` (`data4es` process stage),
- `Utils/Dataflow/data4es/071_consistency` (consistency check process stage).

------

The default behavior must not have changed for the default settings are kept as they were hard-coded originally