### PR TITLE
Unify es index config

### DIFF
--- a/Utils/Dataflow/data4es/071_esConsistency/consistency.py
+++ b/Utils/Dataflow/data4es/071_esConsistency/consistency.py
@@ -61,7 +61,7 @@ def load_config(fname):
         'ES_USER': '',
         'ES_PASSWORD': '',
         'ES_CA_CERTS': '/etc/pki/tls/certs/CERN-bundle.pem',
-        'ES_INDEX': ''
+        'ES_INDEX_TASKS': ''
     }
     with open(fname) as f:
         lines = f.readlines()
@@ -76,7 +76,7 @@ def load_config(fname):
             if key in cfg:
                 cfg[key] = value
     global INDEX
-    INDEX = cfg['ES_INDEX']
+    INDEX = cfg['ES_INDEX_TASKS']
     return cfg
 
 

--- a/Utils/Elasticsearch/config/es.example
+++ b/Utils/Elasticsearch/config/es.example
@@ -15,10 +15,3 @@ ES_INDEX_PROGRESS=production_progress
                                  # avail: production_progress,
                                  #        analysis_progress
 
-
-# ---
-#
-# This variable is left for backwards compatibility:
-# some stages of the `data4es` dataflow rely on it.
-# TODO: replace with ES_INDEX_TASKS everywhere
-ES_INDEX=tasks_production        #default index to work with


### PR DESCRIPTION
Remove config parameter `ES_INDEX`, which was "left for backwards compatibility".
Feels like only Stage071 (consistency checker) used to rely on this one.