### PR TITLE
fix(consistency): missed ES `_type` in data flow

### DIFF
--- a/Utils/Dataflow/data4es/071_esConsistency/consistency.py
+++ b/Utils/Dataflow/data4es/071_esConsistency/consistency.py
@@ -152,7 +152,7 @@ def process(stage, message):
         return False
     try:
         _id = data.pop('_id')
-        _type = data.pop('_type')
+        _type = data.pop('_type', '_doc')
     except KeyError:
         log('Insufficient ES info in data:' + str(data), 'WARN')
         return False


### PR DESCRIPTION
Now consistency check must work properly (with both old and actual versions, if it matters).